### PR TITLE
Provide text alternatives for image only buttons increasing overal app accessibility

### DIFF
--- a/app/src/main/res/layout/layout_player_status.xml
+++ b/app/src/main/res/layout/layout_player_status.xml
@@ -51,7 +51,8 @@
             android:minHeight="100dp"
             android:minWidth="100dp"
             android:src="@drawable/ic_stop_24dp"
-            android:layout_margin="10dp" />
+            android:layout_margin="10dp"
+            android:contentDescription="@string/detail_stop" />
 
         <TextView
             android:id="@+id/textViewCountdown"
@@ -90,7 +91,8 @@
                 android:minWidth="50dp"
                 android:src="@drawable/ic_delete_black_24dp"
                 android:layout_margin="10dp"
-                android:layout_gravity="center" />
+                android:layout_gravity="center"
+                android:contentDescription="@string/image_button_disable" />
 
             <ImageButton
                 android:layout_width="wrap_content"
@@ -100,7 +102,8 @@
                 android:minWidth="50dp"
                 android:src="@drawable/ic_fiber_manual_record_black_24dp"
                 android:layout_margin="10dp"
-                android:layout_gravity="center" />
+                android:layout_gravity="center"
+                android:contentDescription="@string/image_button_record" />
         </LinearLayout>
 
         <TextView

--- a/app/src/main/res/layout/list_item_alarm.xml
+++ b/app/src/main/res/layout/list_item_alarm.xml
@@ -54,7 +54,8 @@
             android:id="@+id/buttonDelete"
             android:src="@drawable/ic_delete_black_24dp"
             android:layout_gravity="center"
-            android:background="@android:color/transparent" />
+            android:background="@android:color/transparent"
+            android:contentDescription="@string/image_button_delete" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/list_item_station.xml
+++ b/app/src/main/res/layout/list_item_station.xml
@@ -45,6 +45,7 @@
         android:background="@android:color/transparent"
         android:layout_margin="5dp"
         android:layout_gravity="center"
-        android:minWidth="40dp" />
+        android:minWidth="40dp"
+        android:contentDescription="@string/image_button_more" />
 
 </LinearLayout>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -68,4 +68,9 @@
 
     <string name="station_detail_bitrate">%1$1d kbps</string>
     <string name="station_detail_broken">NEFUNKČNÁ</string>
+
+    <string name="image_button_disable">Zakázať</string>
+    <string name="image_button_record">Nahrávať</string>
+    <string name="image_button_delete">Odstrániť</string>
+    <string name="image_button_more">Viac</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,4 +68,9 @@
 
     <string name="station_detail_bitrate">%1$1d kbps</string>
     <string name="station_detail_broken">BROKEN</string>
+
+    <string name="image_button_disable">Disable</string>
+    <string name="image_button_record">Record</string>
+    <string name="image_button_delete">Delete</string>
+    <string name="image_button_more">More</string>
 </resources>


### PR DESCRIPTION
This is mainly useful to visually disabled users relying on assistive technologies.
I have tested this on Android 6.0.1, however setting contentDescription is supported since android 1.6 so this is risk free as far as RadioDroid compatibility is concerned.
For me this is working as intended. Visually disabled or blind people in general like to play online radio, so by accepting this you are doing great service to me and other people who may benefit.