### PR TITLE
proxy - do not stop on error; increase buffer & timeout

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/PlayerService.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/PlayerService.java
@@ -305,6 +305,10 @@ public class PlayerService extends Service implements IStreamProxyEventReceiver 
 		itsStationID = theID;
 		itsStationName = theName;
 		itsStationURL = theURL;
+		ReplayCurrent(isAlarm);
+	}
+
+	public void ReplayCurrent(final boolean isAlarm) {
 		liveInfo = null;
 		streamInfo = null;
 		SetPlayStatus(PlayStatus.Idle);
@@ -459,6 +463,7 @@ public class PlayerService extends Service implements IStreamProxyEventReceiver 
 	@Override
 	public void streamStopped() {
 		Stop();
+		ReplayCurrent(false);
 	}
 
 	public void Stop() {

--- a/app/src/main/java/net/programmierecke/radiodroid2/StreamProxy.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/StreamProxy.java
@@ -94,7 +94,7 @@ public class StreamProxy {
                     // connect to stream
                     URLConnection connection = new URL(uri).openConnection();
                     connection.setConnectTimeout(5000);
-                    connection.setReadTimeout(5000);
+                    connection.setReadTimeout(10000);
                     connection.setRequestProperty("Icy-MetaData", "1");
                     connection.connect();
 
@@ -120,7 +120,7 @@ public class StreamProxy {
                         filterOutMetaData = true;
                     }
 
-                    byte buf[] = new byte[16384];
+                    byte buf[] = new byte[163840];
                     byte bufMetadata[] = new byte[256 * 16];
                     int readBytesBuffer = 0;
                     int readBytesBufferMetadata = 0;
@@ -188,14 +188,14 @@ public class StreamProxy {
                         retry = MaxRetries;
                     }
                 } catch (Exception e) {
-                    Log.e(TAG, "Play()" + e);
+                    Log.e(TAG, "Inside loop ex Proxy()" + e);
                 }
 
                 retry--;
                 Thread.sleep(1000);
             }
         } catch (InterruptedException e) {
-            Log.e(TAG,"Play() "+e);
+            Log.e(TAG,"Interrupted ex Proxy() "+e);
         }
         // inform outside if stream stopped, only if outside did not initiate stop
         if (!isStopped){


### PR DESCRIPTION
PlayerService: Replay current stream instead of stopping in case of proxy problems

StreamProxy: Increase buffer, read timeout
more detailed logging

About the changes: These are mainly changes that affect the way that radiodroid behaves
when being used with bad (or varying) internet connection.
Currently, radio droid is Playerservice is being stopped if the proxy has for example a streaming error
or bad connection. That means that you have to manually restart the stream each time
this happens. This is very undesirable - you have to pull the smartphone out and act every time.
With this change, instead it tries to restart streaming by itself. No manual intervention needed.
Stopping a stream manually works as usual.

The increased buffer also improves playback quality, however, it is not possible yet to make an even greater buffer with the current implementation because of resulting error in the output stream.

Future ideas: Use buffers from OKhttp - no need to re-implement buffers.
With their help it is easily possible to resume playback at the correct position as they allow
to search within byte stream. Currently with a bad connection several parts may be played 
twice which sounds odd.

It should also be no problem to create a buffer that can hold some minutes of music to 
be able to have continuous playing even in situations of bad connections (e.g. in train or 
during biking).