### PR TITLE
Add setting to display Starred Radio at startup

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,6 +49,10 @@
     <string name="settings_show_broken_on">Show broken stations in lists</string>
     <string name="settings_show_broken_off">Do not show broken stations in lists</string>
 
+    <string name="settings_starred_at_startup">Starred stations at startup</string>
+    <string name="settings_starred_at_startup_on">Show starred stations when starting RadioDroid</string>
+    <string name="settings_starred_at_startup_off">Show all stations when starting RadioDroid</string>
+
     <string name="settings_alarm">Alarm</string>
     <string name="settings_alarm_external">Open external</string>
     <string name="settings_alarm_external_desc">Open the alarm with default external app</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -16,6 +16,12 @@
             android:summaryOn="@string/settings_show_broken_on"
             android:summaryOff="@string/settings_show_broken_off" />
 
+        <CheckBoxPreference
+            android:key="starred_at_startup"
+            android:title="@string/settings_starred_at_startup"
+            android:summaryOn="@string/settings_starred_at_startup_on"
+            android:summaryOff="@string/settings_starred_at_startup_off" />
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
#### Objective
Add an option to display Starred Stations at application startup

#### Way
Look at the shared pref on MainActivity onResume and pick the right Fragment to display accordingly

#### Reason
When using RadioDroid, I realized I was systematically going to starred radios panel as soon as the app was started. I thought maybe the app could do that for me.