### PR TITLE
fix exception on clicking alarm

### DIFF
--- a/app/src/main/res/layout/list_item_alarm.xml
+++ b/app/src/main/res/layout/list_item_alarm.xml
@@ -21,9 +21,7 @@
             android:height="50dp"
             android:layout_marginLeft="15dp"
             android:layout_marginTop="15dp"
-            android:layout_marginRight="15dp"
-            android:onClick="onClick"
-            android:clickable="true" />
+            android:layout_marginRight="15dp" />
 
         <TextView
             android:id="@+id/textViewStation"


### PR DESCRIPTION
**reason:** Removing the "clickable flag" on the textview "alarm time" which causes the app to break on click.
**explanation**: i tried to add  the onClickListener with the TimePicker only to the textview holding the alarm time. I forgot to remove the flag. Sorry