### PR TITLE
Fix pressing station's 'more' button plays it.

### DIFF
--- a/app/src/main/res/layout/list_item_station.xml
+++ b/app/src/main/res/layout/list_item_station.xml
@@ -38,14 +38,14 @@
     </LinearLayout>
 
     <ImageButton
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
         android:id="@+id/buttonMore"
-        android:src="@drawable/ic_more_vert_black_24dp"
-        android:background="@android:color/transparent"
-        android:layout_margin="5dp"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
         android:layout_gravity="center"
-        android:minWidth="40dp"
-        android:contentDescription="@string/image_button_more" />
+        android:padding="5dp"
+        android:background="@android:color/transparent"
+        android:contentDescription="@string/image_button_more"
+        android:minWidth="50dp"
+        android:src="@drawable/ic_more_vert_black_24dp" />
 
 </LinearLayout>


### PR DESCRIPTION
The button which calls menu for a station had too small size which cause accidental play of the station.
![image](https://user-images.githubusercontent.com/3993671/28748546-27cf7ffe-74c3-11e7-9396-166dd465d743.png)
