### PR TITLE
Make history manager store station chronologically and without duplicates

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/HistoryManager.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/HistoryManager.java
@@ -5,7 +5,7 @@ import android.content.Context;
 import net.programmierecke.radiodroid2.data.DataRadioStation;
 
 public class HistoryManager extends StationSaveManager{
-    int MAXSIZE = 25;
+    private static final int MAXSIZE = 25;
 
     @Override
     protected String getSaveId(){
@@ -18,13 +18,21 @@ public class HistoryManager extends StationSaveManager{
 
     @Override
     public void add(DataRadioStation station){
+        DataRadioStation stationFromHistory = getById(station.ID);
+        if (stationFromHistory != null) {
+            int oldIndex = listStations.indexOf(stationFromHistory);
+            listStations.remove(oldIndex);
+            listStations.add(0, stationFromHistory);
+            Save();
+            return;
+        }
+
         cutList(MAXSIZE - 1);
         super.addFront(station);
     }
 
-    public void cutList(int count){
-
-        while (listStations.size() > count){
+    private void cutList(int count){
+        if (listStations.size() > count){
             listStations = listStations.subList(0,count);
         }
     }


### PR DESCRIPTION
At the moment history manager stores duplicates which I think isn't a useful behaviour. I propose to store only unique stations and move last played ones to the top of the list.