### PR TITLE
Refactor PlayerService. Add media button support. Add pause/resume. Other small improvements

### DIFF
--- a/app/src/main/aidl/net/programmierecke/radiodroid2/IPlayerService.aidl
+++ b/app/src/main/aidl/net/programmierecke/radiodroid2/IPlayerService.aidl
@@ -1,7 +1,9 @@
 package net.programmierecke.radiodroid2;
 interface IPlayerService
 {
-void Play(String theUrl,String theName,String theID, boolean useExo, boolean isAlarm);
+void Play(String theUrl,String theName,String theID, boolean isAlarm);
+void Pause();
+void Resume();
 void Stop();
 void addTimer(int secondsAdd);
 void clearTimer();
@@ -21,6 +23,6 @@ void startRecording();
 void stopRecording();
 boolean isRecording();
 String getCurrentRecordFileName();
-long getTransferedBytes();
+long getTransferredBytes();
 boolean getIsHls();
 }

--- a/app/src/main/java/net/programmierecke/radiodroid2/AlarmReceiver.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/AlarmReceiver.java
@@ -98,7 +98,7 @@ public class AlarmReceiver extends BroadcastReceiver {
             Log.v(TAG, "Service came online");
             itsPlayerService = IPlayerService.Stub.asInterface(binder);
             try {
-                itsPlayerService.Play(url, station.Name, station.ID, true, true);
+                itsPlayerService.Play(url, station.Name, station.ID, true);
                 // default timeout 1 hour
                 itsPlayerService.addTimer(timeout*60);
             } catch (RemoteException e) {

--- a/app/src/main/java/net/programmierecke/radiodroid2/BecomingNoisyReceiver.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/BecomingNoisyReceiver.java
@@ -1,0 +1,16 @@
+package net.programmierecke.radiodroid2;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.media.AudioManager;
+
+public class BecomingNoisyReceiver extends BroadcastReceiver {
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (AudioManager.ACTION_AUDIO_BECOMING_NOISY.equals(intent.getAction())) {
+            PlayerServiceUtil.pause();
+        }
+    }
+}

--- a/app/src/main/java/net/programmierecke/radiodroid2/PlayerService.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/PlayerService.java
@@ -1,10 +1,5 @@
 package net.programmierecke.radiodroid2;
 
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.util.ArrayList;
 import java.util.Map;
 
 import android.app.Notification;
@@ -12,642 +7,659 @@ import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.graphics.drawable.BitmapDrawable;
 import android.media.AudioManager;
-import android.media.MediaPlayer;
-import android.media.PlaybackParams;
-import android.net.Uri;
 import android.net.wifi.WifiManager;
 import android.os.Build;
 import android.os.CountDownTimer;
 import android.os.Handler;
 import android.os.IBinder;
-import android.os.Looper;
 import android.os.PowerManager;
 import android.os.RemoteException;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.content.res.ResourcesCompat;
+import android.support.v4.media.session.MediaSessionCompat;
+import android.support.v4.media.session.PlaybackStateCompat;
 import android.text.TextUtils;
 import android.util.Log;
+import android.view.KeyEvent;
 import android.widget.Toast;
 
-import com.google.android.exoplayer2.DefaultLoadControl;
-import com.google.android.exoplayer2.ExoPlayerFactory;
-import com.google.android.exoplayer2.LoadControl;
-import com.google.android.exoplayer2.SimpleExoPlayer;
-import com.google.android.exoplayer2.extractor.DefaultExtractorsFactory;
-import com.google.android.exoplayer2.extractor.ExtractorsFactory;
-import com.google.android.exoplayer2.source.ExtractorMediaSource;
-import com.google.android.exoplayer2.source.MediaSource;
-import com.google.android.exoplayer2.trackselection.AdaptiveTrackSelection;
-import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
-import com.google.android.exoplayer2.trackselection.TrackSelection;
-import com.google.android.exoplayer2.trackselection.TrackSelector;
-import com.google.android.exoplayer2.upstream.DataSource;
-import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
-import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
-import com.google.android.exoplayer2.util.Util;
-
 import net.programmierecke.radiodroid2.data.ShoutcastInfo;
-import net.programmierecke.radiodroid2.interfaces.IStreamProxyEventReceiver;
-
-import static android.media.AudioManager.AUDIOFOCUS_LOSS_TRANSIENT;
-
-public class PlayerService extends Service implements IStreamProxyEventReceiver {
-	protected static final int NOTIFY_ID = 1;
-	public static final String PLAYER_SERVICE_TIMER_UPDATE = "net.programmierecke.radiodroid2.timerupdate";
-	public static final String PLAYER_SERVICE_STATUS_UPDATE = "net.programmierecke.radiodroid2.statusupdate";
-	public static final String PLAYER_SERVICE_META_UPDATE = "net.programmierecke.radiodroid2.metaupdate";
-
-	final String TAG = "PLAY";
-
-	private Context itsContext;
-
-	private String itsStationID;
-	private String itsStationName;
-	private String itsStationURL;
-	private MediaPlayer itsMediaPlayer = null;
-	SimpleExoPlayer player = null;
-	private CountDownTimer timer = null;
-	long seconds = 0;
-	private Map<String, String> liveInfo;
-	private ShoutcastInfo streamInfo;
-	private StreamProxy proxy;
-
-	PlayStatus playStatus = PlayStatus.Idle;
-	private PowerManager powerManager;
-	private PowerManager.WakeLock wakeLock;
-	private WifiManager.WifiLock wifiLock;
-	private boolean isHls = false;
-	boolean useExo = false;
-	private boolean isAlarm = false;
-
-	enum PlayStatus{
-		Idle,
-		CreateProxy,
-		ClearOld,
-		PrepareStream,
-		PrePlaying, Playing
-	}
-
-	void sendBroadCast(String action){
-		Intent local = new Intent();
-		local.setAction(action);
-		sendBroadcast(local);
-	}
-
-	private final IPlayerService.Stub itsBinder = new IPlayerService.Stub() {
-
-		public void Play(String theUrl, String theName, String theID, boolean useExo, boolean isAlarm) throws RemoteException {
-			PlayerService.this.PlayUrl(theUrl, theName, theID, useExo, isAlarm);
-		}
-
-		public void Stop() throws RemoteException {
-			PlayerService.this.Stop();
-		}
-
-		@Override
-		public void addTimer(int secondsAdd) throws RemoteException {
-			PlayerService.this.addTimer(secondsAdd);
-		}
-
-		@Override
-		public void clearTimer() throws RemoteException {
-			PlayerService.this.clearTimer();
-		}
-
-		@Override
-		public long getTimerSeconds() throws RemoteException {
-			return PlayerService.this.getTimerSeconds();
-		}
-
-		@Override
-		public String getCurrentStationID() throws RemoteException {
-			if (playStatus != PlayStatus.Idle) {
-				return itsStationID;
-			}
-			return null;
-		}
-
-		@Override
-		public String getStationName() throws RemoteException {
-			return itsStationName;
-		}
-
-		@Override
-		public Map getMetadataLive() throws RemoteException {
-			return PlayerService.this.liveInfo;
-		}
-
-		@Override
-		public String getMetadataStreamName() throws RemoteException {
-			if (streamInfo != null)
-				return streamInfo.audioName;
-			return null;
-		}
-
-		@Override
-		public String getMetadataServerName() throws RemoteException {
-			if (streamInfo != null)
-				return streamInfo.serverName;
-			return null;
-		}
-
-		@Override
-		public String getMetadataGenre() throws RemoteException {
-			if (streamInfo != null)
-				return streamInfo.audioGenre;
-			return null;
-		}
-
-		@Override
-		public String getMetadataHomepage() throws RemoteException {
-			if (streamInfo != null)
-				return streamInfo.audioHP;
-			return null;
-		}
-
-		@Override
-		public int getMetadataBitrate() throws RemoteException {
-			if (streamInfo != null)
-				return streamInfo.bitrate;
-			return 0;
-		}
-
-		@Override
-		public int getMetadataSampleRate() throws RemoteException {
-			if (streamInfo != null)
-				return streamInfo.sampleRate;
-			return 0;
-		}
-
-		@Override
-		public int getMetadataChannels() throws RemoteException {
-			if (streamInfo != null)
-				return streamInfo.channels;
-			return 0;
-		}
-
-		@Override
-		public boolean getIsHls() throws RemoteException {
-			return isHls;
-		}
-
-		@Override
-		public boolean isPlaying() throws RemoteException {
-			return playStatus != PlayStatus.Idle;
-		}
-
-		@Override
-		public void startRecording() throws RemoteException {
-			if (proxy != null){
-				proxy.record(itsStationName);
-				sendBroadCast(PLAYER_SERVICE_META_UPDATE);
-			}
-		}
-
-		@Override
-		public void stopRecording() throws RemoteException {
-			if (proxy != null){
-				proxy.stopRecord();
-				sendBroadCast(PLAYER_SERVICE_META_UPDATE);
-			}
-		}
-
-		@Override
-		public boolean isRecording() throws RemoteException {
-			if (proxy != null){
-				return proxy.getOutFileName() != null;
-			}
-			return false;
-		}
-
-		@Override
-		public String getCurrentRecordFileName() throws RemoteException {
-			if (proxy != null){
-				return proxy.getOutFileName();
-			}
-			return null;
-		}
-
-		@Override
-		public long getTransferedBytes() throws RemoteException {
-			if (proxy != null) {
-				return proxy.getTotalBytes();
-			}
-			return 0;
-		}
-	};
-
-	private long getTimerSeconds() {
-		return seconds;
-	}
-
-	private void clearTimer() {
-		if (timer != null) {
-			timer.cancel();
-			timer = null;
-
-			seconds = 0;
-
-			sendBroadCast(PLAYER_SERVICE_TIMER_UPDATE);
-		}
-	}
-
-	private void addTimer(int secondsAdd) {
-		if (timer != null) {
-			timer.cancel();
-			timer = null;
-		}
-
-		seconds += secondsAdd;
-
-		timer = new CountDownTimer(seconds * 1000, 1000) {
-			public void onTick(long millisUntilFinished) {
-				seconds = millisUntilFinished / 1000;
-				Log.w(TAG,""+seconds);
-
-				Intent local = new Intent();
-				local.setAction(PLAYER_SERVICE_TIMER_UPDATE);
-				sendBroadcast(local);
-			}
-			public void onFinish() {
-				Stop();
-				timer = null;
-			}
-		}.start();
-	}
-
-	@Override
-	public IBinder onBind(Intent arg0) {
-		return itsBinder;
-	}
-
-	@Override
-	public void onCreate() {
-		super.onCreate();
-		itsContext = this;
-		timer = null;
-		powerManager = (PowerManager) itsContext.getSystemService(Context.POWER_SERVICE);
-		audioManager = (AudioManager) itsContext.getSystemService(Context.AUDIO_SERVICE);
-	}
-
-	AudioManager audioManager;
-
-	@Override
-	public int onStartCommand (Intent intent, int flags, int startId){
-		if (intent != null) {
-			String action = intent.getAction();
-			if (action != null) {
-				if (action.equals("stop")) {
-					Stop();
-				}
-			}
-		}
-
-		return super.onStartCommand(intent,flags,startId);
-	}
-
-	public void SendMessage(String theTitle, String theMessage, String theTicker) {
-		Intent notificationIntent = new Intent(itsContext, ActivityPlayerInfo.class);
-		notificationIntent.putExtra("stationid", itsStationID);
-		notificationIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-
-		Intent stopIntent = new Intent(itsContext, PlayerService.class);
-		stopIntent.setAction("stop");
-		PendingIntent pendingIntentStop = PendingIntent.getService(itsContext, 0, stopIntent, 0);
-
-		PendingIntent contentIntent = PendingIntent.getActivity(itsContext, 0, notificationIntent, PendingIntent.FLAG_UPDATE_CURRENT);
-		Notification itsNotification = new NotificationCompat.Builder(itsContext)
-				.setContentIntent(contentIntent)
-				.setContentTitle(theTitle)
-				.setContentText(theMessage)
-				.setWhen(System.currentTimeMillis())
-				.setTicker(theTicker)
-				.setOngoing(true)
-				.setUsesChronometer(true)
-				.setSmallIcon(R.drawable.ic_play_arrow_24dp)
-				.setLargeIcon((((BitmapDrawable) ResourcesCompat.getDrawable(getResources(), R.drawable.ic_launcher, null)).getBitmap()))
-				.addAction(R.drawable.ic_stop_24dp,"Stop",pendingIntentStop)
-				.build();
-
-		startForeground(NOTIFY_ID, itsNotification);
-	}
-
-	@Override
-	public void onDestroy() {
-		Log.i(TAG,"onDestroy()");
-		Stop();
-	}
-
-	public void PlayUrl(String theURL, String theName, String theID, final boolean useExo, final boolean isAlarm) {
-		itsStationID = theID;
-		itsStationName = theName;
-		itsStationURL = theURL;
-		this.useExo = useExo;
-
-		int result = audioManager.requestAudioFocus(afChangeListener,
-				// Use the music stream.
-				AudioManager.STREAM_MUSIC,
-				// Request permanent focus.
-				AudioManager.AUDIOFOCUS_GAIN);
-		if (result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
-			//am.registerMediaButtonEventReceiver(RemoteControlReceiver);
-			// Start playback.
-			ReplayCurrent(isAlarm);
-		}else{
-			ToastOnUi(R.string.error_grant_audiofocus);
-		}
-	}
-
-	AudioManager.OnAudioFocusChangeListener afChangeListener =
-			new AudioManager.OnAudioFocusChangeListener() {
-				public void onAudioFocusChange(int focusChange) {
-					if (focusChange == AUDIOFOCUS_LOSS_TRANSIENT) {
-						// Pause playback
-						if (itsMediaPlayer != null) {
-							itsMediaPlayer.pause();
-						}
-					} else if (focusChange == AudioManager.AUDIOFOCUS_GAIN) {
-						// Resume playback
-						if (itsMediaPlayer != null) {
-							itsMediaPlayer.start();
-						}
-					} else if (focusChange == AudioManager.AUDIOFOCUS_LOSS) {
-						//am.unregisterMediaButtonEventReceiver(RemoteControlReceiver);
-						audioManager.abandonAudioFocus(afChangeListener);
-						// Stop playback
-						Stop();
-					}
-				}
-			};
-
-	public void ReplayCurrent(final boolean isAlarm) {
-		liveInfo = null;
-		streamInfo = null;
-		this.isAlarm = isAlarm;
-		SetPlayStatus(PlayStatus.Idle);
-
-		if (wakeLock == null) {
-			wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "PlayerService");
-		}
-		if (!wakeLock.isHeld()) {
-			Log.i(TAG,"acquire wakelock");
-			wakeLock.acquire();
-		}
-		WifiManager wm = (WifiManager) itsContext.getSystemService(Context.WIFI_SERVICE);
-		if (wm != null) {
-
-			if (wifiLock == null) {
-				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB_MR1) {
-					wifiLock = wm.createWifiLock(WifiManager.WIFI_MODE_FULL_HIGH_PERF, "PlayerService");
-				} else {
-					wifiLock = wm.createWifiLock(WifiManager.WIFI_MODE_FULL, "PlayerService");
-				}
-			}
-			if (!wifiLock.isHeld()) {
-				Log.i(TAG,"acquire wifilock");
-				wifiLock.acquire();
-			}
-		}else{
-			Log.e(TAG,"could not aquire wifi lock");
-		}
-
-		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
-			// use old MediaPlayer on API levels < 16
-			// https://github.com/google/ExoPlayer/issues/711
-			useExo = false;
-		}
-
-		/*new Thread(new Runnable() {
-			@Override
-			public void run() {*/
-				if (proxy != null){
-					Log.i(TAG,"stop old proxy");
-					proxy.stop();
-					proxy = null;
-				}
-
-				SetPlayStatus(PlayStatus.CreateProxy);
-				proxy = new StreamProxy(PlayerService.this, itsStationURL, PlayerService.this);
-        /*
-			}
-		}).start();
-		*/
-	}
-
-	void ToastOnUi(final int messageId){
-		Handler h = new Handler(itsContext.getMainLooper());
-
-		h.post(new Runnable() {
-			@Override
-			public void run() {
-				Toast.makeText(itsContext,itsContext.getResources().getString(messageId),Toast.LENGTH_SHORT).show();
-			}
-		});
-	}
-
-	void SetPlayStatus(PlayStatus status){
-		playStatus = status;
-		UpdateNotification();
-	}
-
-	private void UpdateNotification() {
-		switch (playStatus){
-			case Idle:
-				break;
-			case CreateProxy:
-				SendMessage(itsStationName, itsContext.getResources().getString(R.string.notify_start_proxy), itsContext.getResources().getString(R.string.notify_start_proxy));
-				break;
-			case ClearOld:
-				SendMessage(itsStationName, itsContext.getResources().getString(R.string.notify_stop_player), itsContext.getResources().getString(R.string.notify_stop_player));
-				break;
-			case PrepareStream:
-				SendMessage(itsStationName, itsContext.getResources().getString(R.string.notify_prepare_stream), itsContext.getResources().getString(R.string.notify_prepare_stream));
-				break;
-			case PrePlaying:
-				SendMessage(itsStationName, itsContext.getResources().getString(R.string.notify_try_play), itsContext.getResources().getString(R.string.notify_try_play));
-				break;
-			case Playing:
-				if (liveInfo != null)
-				{
-					String title = liveInfo.get("StreamTitle");
-					if (!TextUtils.isEmpty(title)) {
-						Log.i(TAG, "update message:"+title);
-						SendMessage(itsStationName, title, title);
-					}else{
-						SendMessage(itsStationName, itsContext.getResources().getString(R.string.notify_play), itsStationName);
-					}
-				}else{
-					SendMessage(itsStationName, itsContext.getResources().getString(R.string.notify_play), itsStationName);
-				}
-				break;
-		}
-	}
-
-	@Override
-	public void foundShoutcastStream(ShoutcastInfo info, boolean isHls) {
-		this.streamInfo = info;
-		this.isHls = isHls;
-		if (info != null) {
-			Log.i(TAG, "Metadata offset:" + info.metadataOffset);
-			Log.i(TAG, "Bitrate:" + info.bitrate);
-			Log.i(TAG, "Name:" + info.audioName);
-			Log.i(TAG, "Hls:" + isHls);
-			if (info.audioName != null) {
-				if (!info.audioName.trim().equals("")) {
-					itsStationName = info.audioName.trim();
-				}
-			}
-			Log.i(TAG, "Server:" + info.serverName);
-			Log.i(TAG, "AudioInfo:" + info.audioInfo);
-		}
-		sendBroadCast(PLAYER_SERVICE_META_UPDATE);
-	}
-
-	@Override
-	public void foundLiveStreamInfo(Map<String, String> liveInfo) {
-		this.liveInfo = liveInfo;
-		for (String key: liveInfo.keySet())
-		{
-			Log.i(TAG,"INFO:"+key+"="+liveInfo.get(key));
-		}
-		sendBroadCast(PLAYER_SERVICE_META_UPDATE);
-		UpdateNotification();
-	}
-
-	@Override
-	public void streamCreated(final String proxyConnection) {
-        new Thread(new Runnable() {
+import net.programmierecke.radiodroid2.players.ExoPlayerWrapper;
+import net.programmierecke.radiodroid2.players.MediaPlayerWrapper;
+import net.programmierecke.radiodroid2.players.RadioPlayer;
+
+public class PlayerService extends Service implements RadioPlayer.PlayerListener {
+    protected static final int NOTIFY_ID = 1;
+
+    public static final String PLAYER_SERVICE_TIMER_UPDATE = "net.programmierecke.radiodroid2.timerupdate";
+    public static final String PLAYER_SERVICE_STATUS_UPDATE = "net.programmierecke.radiodroid2.statusupdate";
+    public static final String PLAYER_SERVICE_META_UPDATE = "net.programmierecke.radiodroid2.metaupdate";
+
+    private final String TAG = "PLAY";
+
+    private final String ACTION_PAUSE = "pause";
+    private final String ACTION_RESUME = "resume";
+    private final String ACTION_STOP = "stop";
+
+    private final float FULL_VOLUME = 100f;
+    private final float DUCK_VOLUME = 40f;
+
+    private Context itsContext;
+
+    private String currentStationID;
+    private String currentStationName;
+    private String currentStationURL;
+
+    private RadioPlayer radioPlayer;
+
+    private AudioManager audioManager;
+    private MediaSessionCompat mediaSession;
+    private PowerManager powerManager;
+    private PowerManager.WakeLock wakeLock;
+    private WifiManager.WifiLock wifiLock;
+
+    private BecomingNoisyReceiver becomingNoisyReceiver = new BecomingNoisyReceiver();
+
+    private CountDownTimer timer;
+    private long seconds = 0;
+
+    private Map<String, String> liveInfo;
+    private ShoutcastInfo streamInfo;
+
+    private boolean isHls = false;
+
+    void sendBroadCast(String action) {
+        Intent local = new Intent();
+        local.setAction(action);
+        sendBroadcast(local);
+    }
+
+    private final IPlayerService.Stub itsBinder = new IPlayerService.Stub() {
+
+        public void Play(String theUrl, String theName, String theID, boolean isAlarm) throws RemoteException {
+            PlayerService.this.PlayUrl(theUrl, theName, theID, isAlarm);
+        }
+
+        public void Pause() throws RemoteException {
+            PlayerService.this.Pause();
+        }
+
+        public void Resume() throws RemoteException {
+            PlayerService.this.Resume();
+        }
+
+        public void Stop() throws RemoteException {
+            PlayerService.this.Stop();
+        }
+
+        @Override
+        public void addTimer(int secondsAdd) throws RemoteException {
+            PlayerService.this.addTimer(secondsAdd);
+        }
+
+        @Override
+        public void clearTimer() throws RemoteException {
+            PlayerService.this.clearTimer();
+        }
+
+        @Override
+        public long getTimerSeconds() throws RemoteException {
+            return PlayerService.this.getTimerSeconds();
+        }
+
+        @Override
+        public String getCurrentStationID() throws RemoteException {
+            return currentStationID;
+        }
+
+        @Override
+        public String getStationName() throws RemoteException {
+            return currentStationName;
+        }
+
+        @Override
+        public Map getMetadataLive() throws RemoteException {
+            return PlayerService.this.liveInfo;
+        }
+
+        @Override
+        public String getMetadataStreamName() throws RemoteException {
+            if (streamInfo != null)
+                return streamInfo.audioName;
+            return null;
+        }
+
+        @Override
+        public String getMetadataServerName() throws RemoteException {
+            if (streamInfo != null)
+                return streamInfo.serverName;
+            return null;
+        }
+
+        @Override
+        public String getMetadataGenre() throws RemoteException {
+            if (streamInfo != null)
+                return streamInfo.audioGenre;
+            return null;
+        }
+
+        @Override
+        public String getMetadataHomepage() throws RemoteException {
+            if (streamInfo != null)
+                return streamInfo.audioHP;
+            return null;
+        }
+
+        @Override
+        public int getMetadataBitrate() throws RemoteException {
+            if (streamInfo != null)
+                return streamInfo.bitrate;
+            return 0;
+        }
+
+        @Override
+        public int getMetadataSampleRate() throws RemoteException {
+            if (streamInfo != null)
+                return streamInfo.sampleRate;
+            return 0;
+        }
+
+        @Override
+        public int getMetadataChannels() throws RemoteException {
+            if (streamInfo != null)
+                return streamInfo.channels;
+            return 0;
+        }
+
+        @Override
+        public boolean getIsHls() throws RemoteException {
+            return isHls;
+        }
+
+        @Override
+        public boolean isPlaying() throws RemoteException {
+            return radioPlayer.isPlaying();
+        }
+
+        @Override
+        public void startRecording() throws RemoteException {
+            if (radioPlayer != null) {
+                radioPlayer.startRecording(currentStationName);
+                sendBroadCast(PLAYER_SERVICE_META_UPDATE);
+            }
+        }
+
+        @Override
+        public void stopRecording() throws RemoteException {
+            if (radioPlayer != null) {
+                radioPlayer.stopRecording();
+                sendBroadCast(PLAYER_SERVICE_META_UPDATE);
+            }
+        }
+
+        @Override
+        public boolean isRecording() throws RemoteException {
+            return radioPlayer != null && radioPlayer.isRecording();
+        }
+
+        @Override
+        public String getCurrentRecordFileName() throws RemoteException {
+            if (radioPlayer != null) {
+                return radioPlayer.getRecordFileName();
+            }
+            return null;
+        }
+
+        @Override
+        public long getTransferredBytes() throws RemoteException {
+            if (radioPlayer != null) {
+                return radioPlayer.getRecordedBytes();
+            }
+            return 0;
+        }
+    };
+
+    private final MediaSessionCompat.Callback mediaSessionCallback = new MediaSessionCompat.Callback() {
+        @Override
+        public boolean onMediaButtonEvent(Intent mediaButtonEvent) {
+            final KeyEvent event = mediaButtonEvent.getParcelableExtra(Intent.EXTRA_KEY_EVENT);
+
+            if (event != null && event.getAction() == KeyEvent.ACTION_DOWN) {
+                switch (event.getKeyCode()) {
+                    case KeyEvent.KEYCODE_MEDIA_PAUSE:
+                        PlayerServiceUtil.pause();
+                        break;
+                    case KeyEvent.KEYCODE_MEDIA_PLAY:
+                        PlayerServiceUtil.resume();
+                        break;
+                }
+            }
+
+            return true;
+        }
+    };
+
+    AudioManager.OnAudioFocusChangeListener afChangeListener =
+            new AudioManager.OnAudioFocusChangeListener() {
+                public void onAudioFocusChange(int focusChange) {
+                    switch (focusChange) {
+                        case AudioManager.AUDIOFOCUS_GAIN:
+                            Log.d(TAG, "audiofocus gain");
+
+                            CreateMediaSession();
+                            Resume();
+
+                            radioPlayer.setVolume(FULL_VOLUME);
+                            break;
+                        case AudioManager.AUDIOFOCUS_LOSS:
+                            Log.d(TAG, "audiofocus loss");
+
+                            Stop();
+                            break;
+                        case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
+                            Log.d(TAG, "audiofocus loss transient");
+
+                            Pause();
+                            break;
+                        case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK:
+                            Log.d(TAG, "audiofocus loss transient can duck");
+
+                            radioPlayer.setVolume(DUCK_VOLUME);
+                            break;
+                    }
+                }
+            };
+
+    private long getTimerSeconds() {
+        return seconds;
+    }
+
+    private void clearTimer() {
+        if (timer != null) {
+            timer.cancel();
+            timer = null;
+
+            seconds = 0;
+
+            sendBroadCast(PLAYER_SERVICE_TIMER_UPDATE);
+        }
+    }
+
+    private void addTimer(int secondsAdd) {
+        if (timer != null) {
+            timer.cancel();
+            timer = null;
+        }
+
+        seconds += secondsAdd;
+
+        timer = new CountDownTimer(seconds * 1000, 1000) {
+            public void onTick(long millisUntilFinished) {
+                seconds = millisUntilFinished / 1000;
+                Log.w(TAG, "" + seconds);
+
+                Intent local = new Intent();
+                local.setAction(PLAYER_SERVICE_TIMER_UPDATE);
+                sendBroadcast(local);
+            }
+
+            public void onFinish() {
+                Stop();
+                timer = null;
+            }
+        }.start();
+    }
+
+    @Override
+    public IBinder onBind(Intent arg0) {
+        return itsBinder;
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        itsContext = this;
+        timer = null;
+        powerManager = (PowerManager) itsContext.getSystemService(Context.POWER_SERVICE);
+        audioManager = (AudioManager) itsContext.getSystemService(Context.AUDIO_SERVICE);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+            radioPlayer = new RadioPlayer(PlayerService.this, new ExoPlayerWrapper());
+        } else {
+            // use old MediaPlayer on API levels < 16
+            // https://github.com/google/ExoPlayer/issues/711
+            radioPlayer = new RadioPlayer(PlayerService.this, new MediaPlayerWrapper());
+        }
+
+        radioPlayer.setPlayerListener(this);
+    }
+
+    @Override
+    public void onDestroy() {
+        Log.i(TAG, "onDestroy()");
+        Stop();
+
+        radioPlayer.destroy();
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        if (intent != null) {
+            String action = intent.getAction();
+            if (action != null) {
+                switch (action) {
+                    case ACTION_STOP:
+                        Stop();
+                        break;
+                    case ACTION_PAUSE:
+                        Pause();
+                        break;
+                    case ACTION_RESUME:
+                        Resume();
+                        break;
+                }
+            }
+        }
+
+        return super.onStartCommand(intent, flags, startId);
+    }
+
+    private void CreateMediaSession() {
+        if (mediaSession == null) {
+            becomingNoisyReceiver = new BecomingNoisyReceiver();
+
+            IntentFilter becomingNoisyFilter = new IntentFilter(AudioManager.ACTION_AUDIO_BECOMING_NOISY);
+            registerReceiver(becomingNoisyReceiver, becomingNoisyFilter);
+
+            mediaSession = new MediaSessionCompat(getBaseContext(), getBaseContext().getPackageName());
+            mediaSession.setCallback(mediaSessionCallback);
+
+            mediaSession.setFlags(MediaSessionCompat.FLAG_HANDLES_MEDIA_BUTTONS);
+            mediaSession.setActive(true);
+
+            SetMediaPlaybackState(PlaybackStateCompat.STATE_NONE);
+        }
+    }
+
+    private void DestroyMediaSession() {
+        if (mediaSession != null) {
+            mediaSession.release();
+            mediaSession = null;
+
+            unregisterReceiver(becomingNoisyReceiver);
+        }
+    }
+
+    private void SetMediaPlaybackState(int state) {
+        if (mediaSession == null) {
+            return;
+        }
+
+        PlaybackStateCompat.Builder playbackStateBuilder = new PlaybackStateCompat.Builder();
+        if (state == PlaybackStateCompat.STATE_PLAYING) {
+            playbackStateBuilder.setActions(PlaybackStateCompat.ACTION_PLAY_PAUSE | PlaybackStateCompat.ACTION_PAUSE);
+        } else if (state == PlaybackStateCompat.STATE_PAUSED) {
+            playbackStateBuilder.setActions(PlaybackStateCompat.ACTION_PLAY_PAUSE | PlaybackStateCompat.ACTION_PLAY);
+        } else {
+            playbackStateBuilder.setActions(PlaybackStateCompat.ACTION_STOP);
+        }
+
+        playbackStateBuilder.setState(state, PlaybackStateCompat.PLAYBACK_POSITION_UNKNOWN, 0);
+        mediaSession.setPlaybackState(playbackStateBuilder.build());
+    }
+
+    public void SendMessage(String theTitle, String theMessage, String theTicker) {
+        Intent notificationIntent = new Intent(itsContext, ActivityPlayerInfo.class);
+        notificationIntent.putExtra("stationid", currentStationID);
+        notificationIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
+        Intent stopIntent = new Intent(itsContext, PlayerService.class);
+        stopIntent.setAction(ACTION_STOP);
+        PendingIntent pendingIntentStop = PendingIntent.getService(itsContext, 0, stopIntent, 0);
+
+        PendingIntent contentIntent = PendingIntent.getActivity(itsContext, 0, notificationIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+        NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(itsContext)
+                .setContentIntent(contentIntent)
+                .setContentTitle(theTitle)
+                .setContentText(theMessage)
+                .setWhen(System.currentTimeMillis())
+                .setTicker(theTicker)
+                .setOngoing(true)
+                .setSmallIcon(R.drawable.ic_play_arrow_24dp)
+                .setLargeIcon((((BitmapDrawable) ResourcesCompat.getDrawable(getResources(), R.drawable.ic_launcher, null)).getBitmap()))
+                .addAction(R.drawable.ic_stop_24dp, "Stop", pendingIntentStop);
+
+        if (radioPlayer.getPlayState() == RadioPlayer.PlayState.Playing) {
+            Intent pauseIntent = new Intent(itsContext, PlayerService.class);
+            pauseIntent.setAction(ACTION_PAUSE);
+            PendingIntent pendingIntentPause = PendingIntent.getService(itsContext, 0, pauseIntent, 0);
+
+            notificationBuilder.addAction(R.drawable.ic_pause_24dp, "Pause", pendingIntentPause);
+            notificationBuilder.setUsesChronometer(true);
+        } else if (radioPlayer.getPlayState() == RadioPlayer.PlayState.Paused) {
+            Intent resumeIntent = new Intent(itsContext, PlayerService.class);
+            resumeIntent.setAction(ACTION_RESUME);
+            PendingIntent pendingIntentResume = PendingIntent.getService(itsContext, 0, resumeIntent, 0);
+
+            notificationBuilder.addAction(R.drawable.ic_play_arrow_24dp, "Resume", pendingIntentResume);
+            notificationBuilder.setUsesChronometer(false);
+        }
+
+        Notification notification = notificationBuilder.build();
+
+        startForeground(NOTIFY_ID, notification);
+    }
+
+    public void PlayUrl(String theURL, String theName, String theID, final boolean isAlarm) {
+        currentStationID = theID;
+        currentStationName = theName;
+        currentStationURL = theURL;
+
+        int result = audioManager.requestAudioFocus(afChangeListener,
+                // Use the music stream.
+                AudioManager.STREAM_MUSIC,
+                // Request permanent focus.
+                AudioManager.AUDIOFOCUS_GAIN);
+        if (result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
+            // Start playback.
+            CreateMediaSession();
+            ReplayCurrent(isAlarm);
+        } else {
+            ToastOnUi(R.string.error_grant_audiofocus);
+        }
+    }
+
+    public void Pause() {
+        Log.i(TAG, "pause()");
+
+        radioPlayer.pause();
+    }
+
+    public void Resume() {
+        Log.i(TAG, "resume()");
+
+        if(!radioPlayer.isPlaying()) {
+            ReplayCurrent(false);
+        }
+    }
+
+    public void Stop() {
+        Log.i(TAG, "stop()");
+
+        DestroyMediaSession();
+
+        audioManager.abandonAudioFocus(afChangeListener);
+
+        radioPlayer.stop();
+
+        liveInfo = null;
+        streamInfo = null;
+        clearTimer();
+        stopForeground(true);
+        sendBroadCast(PLAYER_SERVICE_STATUS_UPDATE);
+
+        if (wakeLock != null) {
+            if (wakeLock.isHeld()) {
+                wakeLock.release();
+                Log.i(TAG, "release wakelock");
+            }
+            wakeLock = null;
+        }
+        if (wifiLock != null) {
+            if (wifiLock.isHeld()) {
+                Log.i(TAG, "release wifilock");
+                wifiLock.release();
+            }
+            wifiLock = null;
+        }
+    }
+
+    public void ReplayCurrent(final boolean isAlarm) {
+        liveInfo = null;
+        streamInfo = null;
+
+        if (wakeLock == null) {
+            wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "PlayerService");
+        }
+        if (!wakeLock.isHeld()) {
+            Log.i(TAG, "acquire wakelock");
+            wakeLock.acquire();
+        }
+        WifiManager wm = (WifiManager) itsContext.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
+        if (wm != null) {
+
+            if (wifiLock == null) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB_MR1) {
+                    wifiLock = wm.createWifiLock(WifiManager.WIFI_MODE_FULL_HIGH_PERF, "PlayerService");
+                } else {
+                    wifiLock = wm.createWifiLock(WifiManager.WIFI_MODE_FULL, "PlayerService");
+                }
+            }
+            if (!wifiLock.isHeld()) {
+                Log.i(TAG, "acquire wifilock");
+                wifiLock.acquire();
+            }
+        } else {
+            Log.e(TAG, "could not aquire wifi lock");
+        }
+
+        radioPlayer.play(currentStationURL, isAlarm);
+    }
+
+    void ToastOnUi(final int messageId) {
+        Handler h = new Handler(itsContext.getMainLooper());
+
+        h.post(new Runnable() {
             @Override
             public void run() {
-            Log.v(TAG, "Stream url:" + proxyConnection);
-            SetPlayStatus(PlayStatus.ClearOld);
+                Toast.makeText(itsContext, itsContext.getResources().getString(messageId), Toast.LENGTH_SHORT).show();
+            }
+        });
+    }
 
-            if (useExo){
-                if (player != null){
-                    player.stop();
+    private void UpdateNotification() {
+        switch (radioPlayer.getPlayState()) {
+            case Idle:
+                break;
+            case CreateProxy:
+                SendMessage(currentStationName, itsContext.getResources().getString(R.string.notify_start_proxy), itsContext.getResources().getString(R.string.notify_start_proxy));
+                break;
+            case ClearOld:
+                SendMessage(currentStationName, itsContext.getResources().getString(R.string.notify_stop_player), itsContext.getResources().getString(R.string.notify_stop_player));
+                break;
+            case PrepareStream:
+                SendMessage(currentStationName, itsContext.getResources().getString(R.string.notify_prepare_stream), itsContext.getResources().getString(R.string.notify_prepare_stream));
+                break;
+            case PrePlaying:
+                SendMessage(currentStationName, itsContext.getResources().getString(R.string.notify_try_play), itsContext.getResources().getString(R.string.notify_try_play));
+                break;
+            case Playing:
+                if (liveInfo != null) {
+                    String title = liveInfo.get("StreamTitle");
+                    if (!TextUtils.isEmpty(title)) {
+                        Log.i(TAG, "update message:" + title);
+                        SendMessage(currentStationName, title, title);
+                    } else {
+                        SendMessage(currentStationName, itsContext.getResources().getString(R.string.notify_play), currentStationName);
+                    }
+                } else {
+                    SendMessage(currentStationName, itsContext.getResources().getString(R.string.notify_play), currentStationName);
+                }
+                break;
+            case Paused:
+                SendMessage(currentStationName, itsContext.getResources().getString(R.string.notify_paused), currentStationName);
+                break;
+        }
+    }
+
+    @Override
+    public void onStateChanged(final RadioPlayer.PlayState state) {
+        // State changed can be called from the player's thread.
+
+        Handler h = new Handler(itsContext.getMainLooper());
+
+        h.post(new Runnable() {
+            @Override
+            public void run() {
+                switch (state) {
+                    case Paused:
+                        SetMediaPlaybackState(PlaybackStateCompat.STATE_PAUSED);
+                        break;
+                    case Playing:
+                        SetMediaPlaybackState(PlaybackStateCompat.STATE_PLAYING);
+
+                        CreateMediaSession();
+                        mediaSession.setActive(true);
+                        break;
+                    default:
+                        SetMediaPlaybackState(PlaybackStateCompat.STATE_NONE);
+
+                        if (mediaSession != null) {
+                            mediaSession.setActive(false);
+                        }
+                        break;
                 }
 
-                Looper.prepare();
+                UpdateNotification();
+            }
+        });
+    }
 
-                if (player == null){
-                    // 1. Create a default TrackSelector
-                    //Handler mainHandler = new Handler();
-                    DefaultBandwidthMeter bandwidthMeter = new DefaultBandwidthMeter();
-                    TrackSelection.Factory videoTrackSelectionFactory = new AdaptiveTrackSelection.Factory(bandwidthMeter);
-                    TrackSelector trackSelector = new DefaultTrackSelector(videoTrackSelectionFactory);
+    @Override
+    public void onPlayerError(int messageId) {
+        ToastOnUi(messageId);
+    }
 
-                    // 2. Create a default LoadControl
-                    LoadControl loadControl = new DefaultLoadControl();
-
-                    // 3. Create the player
-                    player = ExoPlayerFactory.newSimpleInstance(itsContext, trackSelector, loadControl);
-                    player.setAudioStreamType(isAlarm ? AudioManager.STREAM_ALARM : AudioManager.STREAM_MUSIC);
-                }
-                // Produces DataSource instances through which media data is loaded.
-                DataSource.Factory dataSourceFactory = new DefaultDataSourceFactory(itsContext, Util.getUserAgent(itsContext, "yourApplicationName"), null);
-                // Produces Extractor instances for parsing the media data.
-                ExtractorsFactory extractorsFactory = new DefaultExtractorsFactory();
-                // This is the MediaSource representing the media to be played.
-                MediaSource videoSource = null;
-                videoSource = new ExtractorMediaSource(Uri.parse(proxyConnection), dataSourceFactory, extractorsFactory, null, null);
-                player.prepare(videoSource);
-                player.setPlayWhenReady(true);
-
-                SetPlayStatus(PlayStatus.Playing);
-
-                Looper.loop();
-            }else
-            {
-                if (itsMediaPlayer == null) {
-                    itsMediaPlayer = new MediaPlayer();
-                }
-                if (itsMediaPlayer.isPlaying()) {
-                    itsMediaPlayer.stop();
-                    itsMediaPlayer.reset();
-                }
-                try {
-                    SetPlayStatus(PlayStatus.PrepareStream);
-                    itsMediaPlayer.setAudioStreamType(isAlarm ? AudioManager.STREAM_ALARM : AudioManager.STREAM_MUSIC);
-                    itsMediaPlayer.setDataSource(proxyConnection);
-                    itsMediaPlayer.prepare();
-                    SetPlayStatus(PlayStatus.PrePlaying);
-                    itsMediaPlayer.start();
-                    SetPlayStatus(PlayStatus.Playing);
-                } catch (IllegalArgumentException e) {
-                    Log.e(TAG, "" + e);
-                    ToastOnUi(R.string.error_stream_url);
-                    Stop();
-                } catch (IOException e) {
-                    Log.e(TAG, "" + e);
-                    ToastOnUi(R.string.error_caching_stream);
-                    Stop();
-                } catch (Exception e) {
-                    Log.e(TAG, "" + e);
-                    ToastOnUi(R.string.error_play_stream);
-                    Stop();
+    @Override
+    public void foundShoutcastStream(ShoutcastInfo info, boolean isHls) {
+        this.streamInfo = info;
+        this.isHls = isHls;
+        if (info != null) {
+            Log.i(TAG, "Metadata offset:" + info.metadataOffset);
+            Log.i(TAG, "Bitrate:" + info.bitrate);
+            Log.i(TAG, "Name:" + info.audioName);
+            Log.i(TAG, "Hls:" + isHls);
+            if (info.audioName != null) {
+                if (!info.audioName.trim().equals("")) {
+                    currentStationName = info.audioName.trim();
                 }
             }
-            }
-        }).start();
-	}
+            Log.i(TAG, "Server:" + info.serverName);
+            Log.i(TAG, "AudioInfo:" + info.audioInfo);
+        }
+        sendBroadCast(PLAYER_SERVICE_META_UPDATE);
+    }
 
-	@Override
-	public void streamStopped() {
-		Stop();
-		ReplayCurrent(false);
-	}
-
-	public void Stop() {
-		Log.i(TAG,"stop()");
-		if (player != null){
-			player.stop();
-			player.release();
-			player = null;
-		}
-		if (itsMediaPlayer != null) {
-			if (itsMediaPlayer.isPlaying()) {
-				itsMediaPlayer.stop();
-			}
-			itsMediaPlayer.release();
-			itsMediaPlayer = null;
-		}
-
-		new Thread(new Runnable() {
-			@Override
-			public void run() {
-				if (proxy != null) {
-					try {
-						proxy.stop();
-					}
-					catch (Exception e){
-						Log.e(TAG,"Stop() "+e);
-					}
-					proxy = null;
-				}
-			}
-		}).start();
-		SetPlayStatus(PlayStatus.Idle);
-		liveInfo = null;
-		streamInfo = null;
-		clearTimer();
-		stopForeground(true);
-		sendBroadCast(PLAYER_SERVICE_STATUS_UPDATE);
-
-		if (wakeLock != null) {
-			if (wakeLock.isHeld()) {
-				wakeLock.release();
-				Log.i(TAG,"release wakelock");
-			}
-			wakeLock = null;
-		}
-		if (wifiLock != null) {
-			if (wifiLock.isHeld()) {
-				Log.i(TAG,"release wifilock");
-				wifiLock.release();
-			}
-			wifiLock = null;
-		}
-	}
+    @Override
+    public void foundLiveStreamInfo(Map<String, String> liveInfo) {
+        this.liveInfo = liveInfo;
+        for (String key : liveInfo.keySet()) {
+            Log.i(TAG, "INFO:" + key + "=" + liveInfo.get(key));
+        }
+        sendBroadCast(PLAYER_SERVICE_META_UPDATE);
+        UpdateNotification();
+    }
 }

--- a/app/src/main/java/net/programmierecke/radiodroid2/PlayerServiceUtil.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/PlayerServiceUtil.java
@@ -59,10 +59,30 @@ public class PlayerServiceUtil {
         }
     }
 
-    public static void play(String result, String name, String id, boolean useExo) {
+    public static void play(String result, String name, String id) {
         if (itsPlayerService != null) {
             try {
-                itsPlayerService.Play(result,name,id, useExo, false);
+                itsPlayerService.Play(result,name,id,false);
+            } catch (RemoteException e) {
+                Log.e("", "" + e);
+            }
+        }
+    }
+
+    public static void pause() {
+        if (itsPlayerService != null) {
+            try {
+                itsPlayerService.Pause();
+            } catch (RemoteException e) {
+                Log.e("", "" + e);
+            }
+        }
+    }
+
+    public static void resume() {
+        if (itsPlayerService != null) {
+            try {
+                itsPlayerService.Resume();
             } catch (RemoteException e) {
                 Log.e("", "" + e);
             }
@@ -222,7 +242,7 @@ public class PlayerServiceUtil {
     public static long getTransferedBytes() {
         if (itsPlayerService != null) {
             try {
-                return itsPlayerService.getTransferedBytes();
+                return itsPlayerService.getTransferredBytes();
             } catch (RemoteException e) {
                 Log.e("", "" + e);
             }

--- a/app/src/main/java/net/programmierecke/radiodroid2/StreamProxy.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/StreamProxy.java
@@ -280,6 +280,11 @@ public class StreamProxy {
                     int port = proxyServer.getLocalPort();
                     localAdress = String.format(Locale.US,"http://localhost:%d",port);
                     Log.i(TAG, "waiting..");
+
+                    if(isStopped) {
+                        break;
+                    }
+
                     callback.streamCreated(localAdress);
                     socketProxy = proxyServer.accept();
                     proxyServer.close();

--- a/app/src/main/java/net/programmierecke/radiodroid2/Utils.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/Utils.java
@@ -200,7 +200,7 @@ public class Utils {
 							share.setDataAndType(Uri.parse(result), "audio/*");
 							context.startActivity(share);
 						}else {
-							PlayerServiceUtil.play(result, station.Name, station.ID, true);
+							PlayerServiceUtil.play(result, station.Name, station.ID);
 						}
 					}
 				} else {

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/ExoPlayerWrapper.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/ExoPlayerWrapper.java
@@ -1,0 +1,108 @@
+package net.programmierecke.radiodroid2.players;
+
+
+import android.content.Context;
+import android.media.AudioManager;
+import android.net.Uri;
+import android.util.Log;
+
+import com.google.android.exoplayer2.DefaultLoadControl;
+import com.google.android.exoplayer2.ExoPlayerFactory;
+import com.google.android.exoplayer2.LoadControl;
+import com.google.android.exoplayer2.SimpleExoPlayer;
+import com.google.android.exoplayer2.extractor.DefaultExtractorsFactory;
+import com.google.android.exoplayer2.extractor.ExtractorsFactory;
+import com.google.android.exoplayer2.source.ExtractorMediaSource;
+import com.google.android.exoplayer2.source.MediaSource;
+import com.google.android.exoplayer2.trackselection.AdaptiveTrackSelection;
+import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
+import com.google.android.exoplayer2.trackselection.TrackSelection;
+import com.google.android.exoplayer2.trackselection.TrackSelector;
+import com.google.android.exoplayer2.upstream.DataSource;
+import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
+import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
+import com.google.android.exoplayer2.util.Util;
+
+public class ExoPlayerWrapper implements PlayerWrapper {
+
+    final private String TAG = "ExoPlayerWrapper";
+
+    private SimpleExoPlayer player;
+    private PlayStateListener stateListener;
+
+    @Override
+    public void play(String proxyConnection, Context context, boolean isAlarm) {
+        Log.v(TAG, "Stream url:" + proxyConnection);
+        stateListener.onStateChanged(RadioPlayer.PlayState.ClearOld);
+
+        if (player != null) {
+            player.stop();
+        }
+
+        if (player == null) {
+            // 1. Create a default TrackSelector
+            //Handler mainHandler = new Handler();
+            DefaultBandwidthMeter bandwidthMeter = new DefaultBandwidthMeter();
+            TrackSelection.Factory videoTrackSelectionFactory = new AdaptiveTrackSelection.Factory(bandwidthMeter);
+            TrackSelector trackSelector = new DefaultTrackSelector(videoTrackSelectionFactory);
+
+            // 2. Create a default LoadControl
+            LoadControl loadControl = new DefaultLoadControl();
+
+            // 3. Create the player
+            player = ExoPlayerFactory.newSimpleInstance(context, trackSelector, loadControl);
+            player.setAudioStreamType(isAlarm ? AudioManager.STREAM_ALARM : AudioManager.STREAM_MUSIC);
+        }
+        // Produces DataSource instances through which media data is loaded.
+        DataSource.Factory dataSourceFactory = new DefaultDataSourceFactory(context, Util.getUserAgent(context, "yourApplicationName"), null);
+        // Produces Extractor instances for parsing the media data.
+        ExtractorsFactory extractorsFactory = new DefaultExtractorsFactory();
+        // This is the MediaSource representing the media to be played.
+        MediaSource videoSource = null;
+        videoSource = new ExtractorMediaSource(Uri.parse(proxyConnection), dataSourceFactory, extractorsFactory, null, null);
+        player.prepare(videoSource);
+        player.setPlayWhenReady(true);
+
+        stateListener.onStateChanged(RadioPlayer.PlayState.Playing);
+    }
+
+    @Override
+    public void pause() {
+        Log.i(TAG, "Pause. Stopping exoplayer.");
+
+        if (player != null) {
+            player.stop();
+            player.release();
+            player = null;
+        }
+    }
+
+    @Override
+    public void stop() {
+        Log.i(TAG, "Stopping exoplayer.");
+
+        if (player != null) {
+            player.stop();
+            player.release();
+            player = null;
+        }
+    }
+
+    @Override
+    public boolean isPlaying() {
+        return player != null && player.getPlayWhenReady();
+
+    }
+
+    @Override
+    public void setVolume(float newVolume) {
+        if (player != null) {
+            player.setVolume(newVolume);
+        }
+    }
+
+    @Override
+    public void setStateListener(PlayStateListener listener) {
+        stateListener = listener;
+    }
+}

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/MediaPlayerWrapper.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/MediaPlayerWrapper.java
@@ -1,0 +1,85 @@
+package net.programmierecke.radiodroid2.players;
+
+import android.content.Context;
+import android.media.AudioManager;
+import android.media.MediaPlayer;
+import android.util.Log;
+
+import net.programmierecke.radiodroid2.R;
+
+import java.io.IOException;
+
+public class MediaPlayerWrapper implements PlayerWrapper {
+
+    final private String TAG = "MediaPlayerWrapper";
+
+    private MediaPlayer mediaPlayer;
+    private PlayStateListener stateListener;
+
+    @Override
+    public void play(String proxyConnection, Context context, boolean isAlarm) {
+        Log.v(TAG, "Stream url:" + proxyConnection);
+        stateListener.onStateChanged(RadioPlayer.PlayState.ClearOld);
+
+        if (mediaPlayer == null) {
+            mediaPlayer = new MediaPlayer();
+        }
+        if (mediaPlayer.isPlaying()) {
+            mediaPlayer.stop();
+            mediaPlayer.reset();
+        }
+        try {
+            stateListener.onStateChanged(RadioPlayer.PlayState.PrepareStream);
+            mediaPlayer.setAudioStreamType(isAlarm ? AudioManager.STREAM_ALARM : AudioManager.STREAM_MUSIC);
+            mediaPlayer.setDataSource(proxyConnection);
+            mediaPlayer.prepare();
+            stateListener.onStateChanged(RadioPlayer.PlayState.PrePlaying);
+            mediaPlayer.start();
+            stateListener.onStateChanged(RadioPlayer.PlayState.Playing);
+        } catch (IllegalArgumentException e) {
+            Log.e(TAG, "" + e);
+            stateListener.onPlayerError(R.string.error_stream_url);
+        } catch (IOException e) {
+            Log.e(TAG, "" + e);
+            stateListener.onPlayerError(R.string.error_caching_stream);
+        } catch (Exception e) {
+            Log.e(TAG, "" + e);
+            stateListener.onPlayerError(R.string.error_play_stream);
+        }
+    }
+
+    @Override
+    public void pause() {
+        if (mediaPlayer != null && mediaPlayer.isPlaying()) {
+            mediaPlayer.pause();
+        }
+    }
+
+    @Override
+    public void stop() {
+        if (mediaPlayer != null) {
+            if (mediaPlayer.isPlaying()) {
+                mediaPlayer.stop();
+            }
+            mediaPlayer.release();
+            mediaPlayer = null;
+        }
+    }
+
+    @Override
+    public boolean isPlaying() {
+        return mediaPlayer != null && mediaPlayer.isPlaying();
+    }
+
+    @Override
+    public void setVolume(float newVolume) {
+        if (mediaPlayer != null) {
+            mediaPlayer.setVolume(newVolume, newVolume);
+        }
+    }
+
+    @Override
+    public void setStateListener(PlayStateListener listener) {
+        stateListener = listener;
+    }
+}

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/PlayerWrapper.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/PlayerWrapper.java
@@ -1,0 +1,23 @@
+package net.programmierecke.radiodroid2.players;
+
+import android.content.Context;
+
+interface PlayerWrapper {
+    interface PlayStateListener {
+        void onStateChanged(RadioPlayer.PlayState state);
+
+        void onPlayerError(final int messageId);
+    }
+
+    void play(String proxyConnection, Context context, boolean isAlarm);
+
+    void pause();
+
+    void stop();
+
+    boolean isPlaying();
+
+    void setVolume(float newVolume);
+
+    void setStateListener(PlayStateListener listener);
+}

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/RadioPlayer.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/RadioPlayer.java
@@ -1,0 +1,236 @@
+package net.programmierecke.radiodroid2.players;
+
+import android.content.Context;
+import android.os.Build;
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.os.Looper;
+import android.util.Log;
+
+import net.programmierecke.radiodroid2.StreamProxy;
+import net.programmierecke.radiodroid2.data.ShoutcastInfo;
+import net.programmierecke.radiodroid2.interfaces.IStreamProxyEventReceiver;
+
+import java.util.Map;
+
+public class RadioPlayer implements IStreamProxyEventReceiver, PlayerWrapper.PlayStateListener {
+
+    final private String TAG = "RadioPlayer";
+
+    public enum PlayState {
+        Idle,
+        CreateProxy,
+        ClearOld,
+        PrepareStream,
+        PrePlaying, Playing, Paused
+    }
+
+    public interface PlayerListener {
+        void onStateChanged(PlayState status);
+
+        void onPlayerError(final int messageId);
+
+        // We are not interested in this events here so they will be forwarded to whoever hold RadioPlayer
+        void foundShoutcastStream(ShoutcastInfo bitrate, boolean isHls);
+
+        void foundLiveStreamInfo(Map<String, String> liveInfo);
+    }
+
+    private PlayerWrapper player;
+    private StreamProxy proxy;
+    private Context mainContext;
+
+    private HandlerThread playerThread;
+    private Handler playerThreadHandler;
+
+    private PlayerListener playerListener;
+    private PlayState playState = PlayState.Idle;
+
+    private boolean isAlarm = false;
+    private String stationUrl;
+
+    public RadioPlayer(Context mainContext, PlayerWrapper playerWrapper) {
+        this.mainContext = mainContext;
+        this.player = playerWrapper;
+
+        playerThread = new HandlerThread("PlayerThread");
+        playerThread.start();
+
+        playerThreadHandler = new Handler(playerThread.getLooper());
+
+        player.setStateListener(this);
+    }
+
+    public final void play(final String stationURL, boolean isAlarm) {
+        this.isAlarm = isAlarm;
+        this.stationUrl = stationURL;
+
+        setState(PlayState.Idle);
+
+        playerThreadHandler.post(new Runnable() {
+            @Override
+            public void run() {
+                if (proxy != null) {
+                    Log.i(TAG, "Stop old proxy");
+                    stopProxy();
+                }
+
+                setState(PlayState.CreateProxy);
+                proxy = new StreamProxy(mainContext, stationURL, RadioPlayer.this);
+            }
+        });
+    }
+
+    public final void pause() {
+        playerThreadHandler.post(new Runnable() {
+            @Override
+            public void run() {
+                player.pause();
+
+                if (proxy != null) {
+                    stopProxy();
+
+                    proxy = null;
+                }
+
+                setState(PlayState.Paused);
+            }
+        });
+    }
+
+    public final void stop() {
+        playerThreadHandler.post(new Runnable() {
+            @Override
+            public void run() {
+                player.stop();
+
+                if (proxy != null) {
+                    stopProxy();
+
+                    setState(PlayState.Idle);
+                }
+            }
+        });
+    }
+
+    public final void destroy() {
+        stop();
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            playerThread.quitSafely();
+        } else {
+            Looper looper = playerThread.getLooper();
+            if (looper != null) {
+                playerThreadHandler.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        playerThread.quit();
+                    }
+                });
+            }
+        }
+    }
+
+    public final boolean isPlaying() {
+        return player.isPlaying();
+    }
+
+    public final void setVolume(float volume) {
+        player.setVolume(volume);
+    }
+
+    public final void startRecording(final String fileName) {
+        if (proxy != null) {
+            proxy.record(fileName);
+        }
+    }
+
+    public final void stopRecording() {
+        if (proxy != null) {
+            proxy.stopRecord();
+        }
+    }
+
+    public final boolean isRecording() {
+        return proxy != null && proxy.getOutFileName() != null;
+    }
+
+    public final String getRecordFileName() {
+        if (proxy != null) {
+            return proxy.getOutFileName();
+        }
+
+        return "";
+    }
+
+    public final long getRecordedBytes() {
+        if (proxy != null) {
+            return proxy.getTotalBytes();
+        }
+
+        return 0;
+    }
+
+    public final void runInPlayerThread(Runnable runnable) {
+        playerThreadHandler.post(runnable);
+    }
+
+    public final void setPlayerListener(PlayerListener listener) {
+        playerListener = listener;
+    }
+
+    public PlayState getPlayState() {
+        return playState;
+    }
+
+    private void setState(PlayState state) {
+        playState = state;
+        playerListener.onStateChanged(state);
+    }
+
+    private void stopProxy() {
+        try {
+            proxy.stop();
+        } catch (Exception e) {
+            Log.e(TAG, "Proxy stop exception: " + e);
+        }
+        proxy = null;
+    }
+
+    @Override
+    public void foundShoutcastStream(ShoutcastInfo bitrate, boolean isHls) {
+        playerListener.foundShoutcastStream(bitrate, isHls);
+    }
+
+    @Override
+    public void foundLiveStreamInfo(Map<String, String> liveInfo) {
+        playerListener.foundLiveStreamInfo(liveInfo);
+    }
+
+    @Override
+    public void streamCreated(final String proxyConnection) {
+        playerThreadHandler.post(new Runnable() {
+            @Override
+            public void run() {
+                player.play(proxyConnection, mainContext, isAlarm);
+            }
+        });
+    }
+
+    @Override
+    public void streamStopped() {
+        stop();
+        play(stationUrl, isAlarm);
+    }
+
+    @Override
+    public void onStateChanged(PlayState state) {
+        setState(state);
+    }
+
+    @Override
+    public void onPlayerError(int messageId) {
+        stop();
+        playerListener.onPlayerError(messageId);
+    }
+}

--- a/app/src/main/res/drawable/ic_pause_24dp.xml
+++ b/app/src/main/res/drawable/ic_pause_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportHeight="24.0"
+        android:viewportWidth="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M6,19h4V5H6v14zm8,-14v14h4V5h-4z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,6 +68,7 @@
     <string name="notify_prepare_stream">Preparing stream..</string>
     <string name="notify_try_play">Try playing</string>
     <string name="notify_play">Playing</string>
+    <string name="notify_paused">Paused</string>
 
     <string name="error_stream_url">Stream url problem</string>
     <string name="error_caching_stream">Stream caching problem</string>


### PR DESCRIPTION
This changes a lot in PlayerService. Should fix: #87 #92, but without auto play when device is connected and issue #73.

I added pause and resume of stations playing which is utilized by notification UI and media button.

Now when e.g. bluetooth headset disconnected play will pause which is desired behavior for media player. Also player will reduce volume if any short sound, like notification, will appear.

I had to refactor PlayerService because it was hard maintain it with new changes.
There were several issues:
- Never ended thread with looper which was used for exo player.
- Spawning new threads for small tasks.
- Too many different layers of logic were in PlayerService like controlling two diferrent players, controlling proxy, updating notifications and so on. Which with new logic was incredibly messy.

So I moved player details behind PlayerWrapper interface which is now implemented by ExoPlayerWrapper and MediaPlayerWrapper. To manage proxy and current player I introduced RadioPlayer. I decided to move all operation concerning players into a separate thread which created once. After that PlayerService uses RadioPlayer whithout bothering about players.

Overall I consider this refactoring to be an impromement to the current state but still I'm not fully satisfied with it, because there are still many possibly unnecessary checks and there is still a possibility for player to go into an unforeseen state.

 Please, review and test changes on your device and discuss if something is wrong or unclear.
