### PR TITLE
Allow to warn when no wifi connection is available

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,8 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 
     <application
         android:allowBackup="false"

--- a/app/src/main/java/net/programmierecke/radiodroid2/Utils.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/Utils.java
@@ -2,11 +2,18 @@ package net.programmierecke.radiodroid2;
 
 import android.Manifest;
 import android.app.Activity;
+import android.app.AlertDialog;
 import android.app.ProgressDialog;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
+import android.content.res.Resources;
+import android.media.AudioManager;
+import android.media.ToneGenerator;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.support.v4.app.ActivityCompat;
@@ -166,6 +173,32 @@ public class Utils {
 	}
 
 	public static void Play(final DataRadioStation station, final Context context, final boolean external) {
+		if (!Utils.hasWifiConnection(context)) {
+			ToneGenerator toneG = new ToneGenerator(AudioManager.STREAM_ALARM, 100);
+			toneG.startTone(ToneGenerator.TONE_SUP_RADIO_NOTAVAIL, 2000);
+			/*Toast.makeText( getBaseContext(), Html.fromHtml( text ), Toast.LENGTH_LONG ).show();
+			finish();*/
+			Resources res = context.getResources();
+			String appName = res.getString(R.string.app_name);
+			String title = res.getString(R.string.no_wifi_title);
+			String text = String.format(res.getString(R.string.no_wifi_connection),	appName);
+			new AlertDialog.Builder(context)
+					.setTitle(title)
+					.setMessage(text)
+					.setNegativeButton(android.R.string.cancel, null) // do not play on cancel
+					.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+						@Override public void onClick(DialogInterface dialog, int which) {
+							playInternal(station, context, external);
+						}
+					})
+					.create()
+					.show();
+		} else {
+			playInternal(station, context, external);
+		}
+	}
+
+	private static void playInternal(final DataRadioStation station, final Context context, final boolean external) {
 		final ProgressDialog itsProgressLoading = ProgressDialog.show(context, "", context.getResources().getText(R.string.progress_loading));
 		new AsyncTask<Void, Void, String>() {
 			@Override
@@ -260,5 +293,12 @@ public class Utils {
 
 	public static String sanitizeName(String str){
 		return str.replaceAll("\\W+", "_");
+	}
+
+	public static boolean hasWifiConnection(Context context) {
+		ConnectivityManager connManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+		NetworkInfo mWifi = connManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
+
+		return mWifi.isConnected();
 	}
 }

--- a/app/src/main/java/net/programmierecke/radiodroid2/Utils.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/Utils.java
@@ -173,7 +173,9 @@ public class Utils {
 	}
 
 	public static void Play(final DataRadioStation station, final Context context, final boolean external) {
-		if (!Utils.hasWifiConnection(context)) {
+		SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(context);
+		final boolean warn_no_wifi = sharedPref.getBoolean("warn_no_wifi", false);
+		if (warn_no_wifi && !Utils.hasWifiConnection(context)) {
 			ToneGenerator toneG = new ToneGenerator(AudioManager.STREAM_ALARM, 100);
 			toneG.startTone(ToneGenerator.TONE_SUP_RADIO_NOTAVAIL, 2000);
 			/*Toast.makeText( getBaseContext(), Html.fromHtml( text ), Toast.LENGTH_LONG ).show();

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -100,4 +100,6 @@
         <item>S</item>
     </string-array>
 
+    <string name="no_wifi_title">Keine WLAN Verbindung</string>
+    <string name="no_wifi_connection">Keine WLAN Verbindung zum Starten von %1$s. Drücken Sie \'Ok\' um fortzufahren.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -63,6 +63,10 @@
     <string name="settings_play_external">Öffne extern</string>
     <string name="settings_play_external_desc">Spiele Radios mit externem Player ab</string>
 
+    <string name="settings_warn_no_wifi">Warnen ohne WLAN Verbindung</string>
+    <string name="settings_warn_no_wifi_on">Warnung when keine WLAN Verbindung besteht</string>
+    <string name="settings_warn_no_wifi_off">Keine Warnung wenn keine WLAN Verbindung besteht</string>
+
     <string name="notify_start_proxy">Starte proxy..</string>
     <string name="notify_stop_player">Stoppe alte Wiedergabe..</string>
     <string name="notify_prepare_stream">Bereite Stream vor..</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,6 +67,10 @@
     <string name="settings_play_external">Open external</string>
     <string name="settings_play_external_desc">Should a single click on stations open external</string>
 
+    <string name="settings_warn_no_wifi">Warn when not on Wifi</string>
+    <string name="settings_warn_no_wifi_on">Warn when playing without Wifi connection</string>
+    <string name="settings_warn_no_wifi_off">No warning when not on Wifi connection</string>
+
     <string name="notify_start_proxy">Starting proxy..</string>
     <string name="notify_stop_player">Stop old player..</string>
     <string name="notify_prepare_stream">Preparing stream..</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -114,4 +114,7 @@
         <item>F</item>
         <item>S</item>
     </string-array>
+
+    <string name="no_wifi_title">No WiFi (WLAN) connection</string>
+    <string name="no_wifi_connection">No WiFi (WLAN) connection when starting %1$s. Press \'Ok\' to continue.</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -38,6 +38,12 @@
             android:title="@string/settings_play_external"
             android:summary="@string/settings_play_external_desc" />
 
+        <CheckBoxPreference
+                android:key="warn_no_wifi"
+                android:title="@string/settings_warn_no_wifi"
+                android:summaryOn="@string/settings_warn_no_wifi_on"
+                android:summaryOff="@string/settings_warn_no_wifi_off" />
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
As this will use the mobile data connection. Added a preference to enable/disable this behavior. The check is done when actually starting to play to allow to browse/bookmark/manage/.. and only warn when playing actually starts.

It also plays a short sound to get the attention of the user, but this can easily removed if you don't want to have this.

Closes #124 