### PR TITLE
Bugfix for switching from native replay to chromecast while playing.

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/Utils.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/Utils.java
@@ -219,6 +219,9 @@ public class Utils {
 						externalActive = true;
 					}
                     if (CastHandler.isCastSessionAvailable()){
+						if (!externalActive) {
+							PlayerServiceUtil.stop(); // stop internal player and not continue playing
+						}
                         CastHandler.PlayRemote(station.Name, result, station.IconUrl);
 						externalActive = true;
                     }


### PR DESCRIPTION
Bugfix for simple bug. When playing natively and switching to chromec…ast, native replay keeps playing in parallel to chromecast.

To trigger the bug:
* Play a radio station natively
* Choose chromecast device for playback
* The native playback continues
* Select a radio station
* Chromecast playback starts in parallel to native replay

Successfully tested the bugfix on a Chromecast setup.
