### PR TITLE
updated for AndroidStudio 3 and gradle3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ local.properties
 
 # Built application files
 /*/build/
+/*/play/
 
 # Local configuration file (sdk path, etc)
 local.properties

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,15 +1,18 @@
 apply plugin: 'com.android.application'
 
 android {
+
+    flavorDimensions "one"
+
     compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    buildToolsVersion '26.0.2'
     lintOptions {
         abortOnError true
     }
 
     defaultConfig {
         applicationId "net.programmierecke.radiodroid2"
-        minSdkVersion 14
+        minSdkVersion 21
         targetSdkVersion 23
 
         versionCode 49
@@ -32,8 +35,12 @@ android {
         }
     }
     productFlavors {
-        play
-        free
+        play {
+            dimension "one"
+        }
+        free {
+            dimension "one"
+        }
     }
 }
 
@@ -55,9 +62,12 @@ dependencies {
 // https://stackoverflow.com/questions/32092665/resolve-application-label-for-each-build-type/32220436#32220436
 // https://stackoverflow.com/questions/18332474/how-to-set-versionname-in-apk-filename-using-gradle
 
+// Gradle 3.0
+// https://stackoverflow.com/questions/44800028/change-apk-filename-in-gradle-failed-with-gradle3-0-0-alpha4
+
 android.applicationVariants.all { variant ->
 
-    variant.outputs.each { output ->
+    variant.outputs.all { output ->
 
         // get app_name field from defaultConfig
         def appName = variant.mergedFlavor.resValues.get('app_name').getValue()
@@ -112,7 +122,7 @@ android.applicationVariants.all { variant ->
         }
 
         finalName += "-" + gitHash() + ".apk"
-        output.outputFile = new File(output.outputFile.parent, finalName)
-
+        // outputFileName = "${variant.name}-${variant.versionName}.apk"
+        outputFileName = finalName
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Oct 20 02:33:26 CEST 2017
+#Wed Oct 25 21:12:10 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
These changes are needed when building with the latest toolchain. Today AndroidStudio3 was published.

See also https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration.html .

Tested. Works.