### PR TITLE
Add 'Swipe to Remove' to history and favourites lists.

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/ActivityMain.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/ActivityMain.java
@@ -345,10 +345,12 @@ public class ActivityMain extends AppCompatActivity implements SearchView.OnQuer
                             .setCancelable(true)
                             .setPositiveButton(this.getString(R.string.yes), new DialogInterface.OnClickListener() {
                                 public void onClick(DialogInterface dialog, int id) {
-                                    Context context = getApplication().getApplicationContext();
-                                    HistoryManager hm = new HistoryManager(context);
-                                    hm.clear();
-                                    Toast toast = Toast.makeText(context, context.getString(R.string.notify_deleted_history), Toast.LENGTH_SHORT);
+                                    RadioDroidApp radioDroidApp = (RadioDroidApp) getApplication();
+                                    HistoryManager historyManager = radioDroidApp.getHistoryManager();
+
+                                    historyManager.clear();
+
+                                    Toast toast = Toast.makeText(getApplicationContext(), getString(R.string.notify_deleted_history), Toast.LENGTH_SHORT);
                                     toast.show();
                                     recreate();
                                 }
@@ -362,10 +364,12 @@ public class ActivityMain extends AppCompatActivity implements SearchView.OnQuer
                             .setCancelable(true)
                             .setPositiveButton(this.getString(R.string.yes), new DialogInterface.OnClickListener() {
                                 public void onClick(DialogInterface dialog, int id) {
-                                    Context context = getApplication().getApplicationContext();
-                                    FavouriteManager fm = new FavouriteManager(context);
-                                    fm.clear();
-                                    Toast toast = Toast.makeText(context, context.getString(R.string.notify_deleted_favorites), Toast.LENGTH_SHORT);
+                                    RadioDroidApp radioDroidApp = (RadioDroidApp) getApplication();
+                                    FavouriteManager favouriteManager = radioDroidApp.getFavouriteManager();
+
+                                    favouriteManager.clear();
+
+                                    Toast toast = Toast.makeText(getApplicationContext(), getString(R.string.notify_deleted_favorites), Toast.LENGTH_SHORT);
                                     toast.show();
                                     recreate();
                                 }

--- a/app/src/main/java/net/programmierecke/radiodroid2/ActivityRadioStationDetail.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/ActivityRadioStationDetail.java
@@ -28,6 +28,7 @@ public class ActivityRadioStationDetail extends AppCompatActivity implements Tim
 	private MenuItem m_Menu_UnStar;
 	private Menu m_Menu;
 	private String stationId;
+	private FavouriteManager favouriteManager;
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
@@ -40,6 +41,9 @@ public class ActivityRadioStationDetail extends AppCompatActivity implements Tim
 		Bundle anExtras = getIntent().getExtras();
 		final String aStationID = anExtras.getString("stationid");
 		stationId = aStationID;
+
+		RadioDroidApp radioDroidApp = (RadioDroidApp) getApplication();
+		favouriteManager = radioDroidApp.getFavouriteManager();
 
 		PlayerServiceUtil.bind(this);
 
@@ -70,14 +74,12 @@ public class ActivityRadioStationDetail extends AppCompatActivity implements Tim
 	}
 
 	void UpdateMenu() {
-		FavouriteManager fm = new FavouriteManager(getApplicationContext());
-
 		if (stationId != null) {
 			if (m_Menu_Star != null) {
-				m_Menu_Star.setVisible(!fm.has(stationId));
+				m_Menu_Star.setVisible(!favouriteManager.has(stationId));
 			}
 			if (m_Menu_UnStar != null) {
-				m_Menu_UnStar.setVisible(fm.has(stationId));
+				m_Menu_UnStar.setVisible(favouriteManager.has(stationId));
 			}
 		} else {
 			if (m_Menu_Star != null) {
@@ -129,8 +131,7 @@ public class ActivityRadioStationDetail extends AppCompatActivity implements Tim
 
 	private void UnStar() {
 		if (itsStation != null) {
-			FavouriteManager fm = new FavouriteManager(getApplicationContext());
-			fm.remove(itsStation.ID);
+			favouriteManager.remove(itsStation.ID);
 			UpdateMenu();
 		}else{
 			Log.e("ABC","empty station info");
@@ -139,8 +140,7 @@ public class ActivityRadioStationDetail extends AppCompatActivity implements Tim
 
 	private void Star() {
 		if (itsStation != null) {
-			FavouriteManager fm = new FavouriteManager(getApplicationContext());
-			fm.add(itsStation);
+			favouriteManager.add(itsStation);
 			UpdateMenu();
 		}else{
 			Log.e("ABC","empty station info");

--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentStarred.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentStarred.java
@@ -1,6 +1,8 @@
 package net.programmierecke.radiodroid2;
 
+import android.graphics.Color;
 import android.os.Bundle;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -18,19 +20,18 @@ public class FragmentStarred extends Fragment implements IAdapterRefreshable {
 
     private RecyclerView rvStations;
 
-    void onStationClick(DataRadioStation theStation) {
-        ActivityMain activity = (ActivityMain) getActivity();
+    private FavouriteManager favouriteManager;
+    private HistoryManager historyManager;
 
+    void onStationClick(DataRadioStation theStation) {
         Utils.Play(theStation, getContext());
 
-        HistoryManager hm = new HistoryManager(activity.getApplicationContext());
-        hm.add(theStation);
+        historyManager.add(theStation);
     }
 
     public void RefreshListGui() {
         if (BuildConfig.DEBUG) Log.d(TAG, "refreshing the stations list.");
 
-        FavouriteManager favouriteManager = new FavouriteManager(getActivity());
         ItemAdapterStation adapter = (ItemAdapterStation) rvStations.getAdapter();
 
         if (BuildConfig.DEBUG) Log.d(TAG, "stations count:" + favouriteManager.listStations.size());
@@ -41,15 +42,40 @@ public class FragmentStarred extends Fragment implements IAdapterRefreshable {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
+
+        RadioDroidApp radioDroidApp = (RadioDroidApp) getActivity().getApplication();
+        historyManager = radioDroidApp.getHistoryManager();
+        favouriteManager = radioDroidApp.getFavouriteManager();
+
         // Inflate the layout for this fragment
         View view = inflater.inflate(R.layout.fragment_stations, container, false);
         rvStations = (RecyclerView) view.findViewById(R.id.recyclerViewStations);
 
         ItemAdapterStation adapter = new ItemAdapterStation(getActivity(), R.layout.list_item_station);
-        adapter.setStationClickListener(new ItemAdapterStation.StationClickListener() {
+        adapter.setStationActionsListener(new ItemAdapterStation.StationActionsListener() {
             @Override
             public void onStationClick(DataRadioStation station) {
                 FragmentStarred.this.onStationClick(station);
+            }
+
+            @Override
+            public void onStationSwiped(final DataRadioStation station) {
+                final int removedIdx = favouriteManager.remove(station.ID);
+
+                RefreshListGui();
+
+                Snackbar snackbar = Snackbar
+                        .make(rvStations, R.string.notify_station_removed_from_list, Snackbar.LENGTH_LONG);
+                snackbar.setAction(R.string.action_station_removed_from_list_undo, new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        favouriteManager.restore(station, removedIdx);
+                        RefreshListGui();
+                    }
+                });
+                snackbar.setActionTextColor(Color.GREEN);
+                snackbar.setDuration(Snackbar.LENGTH_LONG);
+                snackbar.show();
             }
         });
 
@@ -58,6 +84,8 @@ public class FragmentStarred extends Fragment implements IAdapterRefreshable {
 
         rvStations.setAdapter(adapter);
         rvStations.setLayoutManager(llm);
+
+        adapter.enableItemRemoval(rvStations);
 
         RefreshListGui();
 

--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentStations.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentStations.java
@@ -22,17 +22,17 @@ public class FragmentStations extends FragmentBase {
     private static final String TAG = "FragmentStations";
 
     private RecyclerView rvStations;
-    private DataRadioStation[] radioStations = new DataRadioStation[0];
     private SwipeRefreshLayout swipeRefreshLayout;
     private SharedPreferences sharedPref;
 
     void onStationClick(DataRadioStation theStation) {
-        ActivityMain a = (ActivityMain) getActivity();
+        ActivityMain activityMain = (ActivityMain) getActivity();
 
         Utils.Play(theStation, getContext());
 
-        HistoryManager hm = new HistoryManager(a.getApplicationContext());
-        hm.add(theStation);
+        RadioDroidApp radioDroidApp = (RadioDroidApp) activityMain.getApplication();
+        HistoryManager historyManager = radioDroidApp.getHistoryManager();
+        historyManager.add(theStation);
     }
 
     @Override
@@ -51,7 +51,7 @@ public class FragmentStations extends FragmentBase {
         boolean show_broken = sharedPref.getBoolean("show_broken", false);
 
         ArrayList<DataRadioStation> filteredStationsList = new ArrayList<>();
-        radioStations = DataRadioStation.DecodeJson(getUrlResult());
+        DataRadioStation[] radioStations = DataRadioStation.DecodeJson(getUrlResult());
 
         if (BuildConfig.DEBUG) Log.d(TAG, "station count:" + radioStations.length);
 
@@ -73,10 +73,14 @@ public class FragmentStations extends FragmentBase {
         rvStations = (RecyclerView) view.findViewById(R.id.recyclerViewStations);
 
         ItemAdapterStation adapter = new ItemAdapterStation(getActivity(), R.layout.list_item_station);
-        adapter.setStationClickListener(new ItemAdapterStation.StationClickListener() {
+        adapter.setStationActionsListener(new ItemAdapterStation.StationActionsListener() {
             @Override
             public void onStationClick(DataRadioStation station) {
                 FragmentStations.this.onStationClick(station);
+            }
+
+            @Override
+            public void onStationSwiped(DataRadioStation station) {
             }
         });
 

--- a/app/src/main/java/net/programmierecke/radiodroid2/RadioDroidApp.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/RadioDroidApp.java
@@ -7,6 +7,10 @@ import com.jakewharton.picasso.OkHttp3Downloader;
 import com.squareup.picasso.Picasso;
 
 public class RadioDroidApp extends Application {
+
+    private HistoryManager historyManager;
+    private FavouriteManager favouriteManager;
+
     @Override
     public void onCreate() {
         super.onCreate();
@@ -19,5 +23,16 @@ public class RadioDroidApp extends Application {
         Picasso.setSingletonInstance(picassoInstance);
 
         CountryFlagsLoader.getInstance().load(this);
+
+        historyManager = new HistoryManager(this);
+        favouriteManager = new FavouriteManager(this);
+    }
+
+    public HistoryManager getHistoryManager() {
+        return historyManager;
+    }
+
+    public FavouriteManager getFavouriteManager() {
+        return favouriteManager;
     }
 }

--- a/app/src/main/java/net/programmierecke/radiodroid2/StationSaveManager.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/StationSaveManager.java
@@ -17,78 +17,90 @@ public class StationSaveManager {
     Context context;
     List<DataRadioStation> listStations = new ArrayList<DataRadioStation>();
 
-    public StationSaveManager(Context ctx){
+    public StationSaveManager(Context ctx) {
         this.context = ctx;
         Load();
     }
 
-    protected String getSaveId(){
+    protected String getSaveId() {
         return "default";
     }
 
-    public void add(DataRadioStation station){
+    public void add(DataRadioStation station) {
         listStations.add(station);
         Save();
     }
 
-    public void addFront(DataRadioStation station){
+    public void addFront(DataRadioStation station) {
         listStations.add(0, station);
         Save();
     }
 
-    DataRadioStation getById(String id){
-        for(DataRadioStation station: listStations){
-            if (id.equals(station.ID)){
+    DataRadioStation getById(String id) {
+        for (DataRadioStation station : listStations) {
+            if (id.equals(station.ID)) {
                 return station;
             }
         }
         return null;
     }
 
-    public void remove(String id){
-        if (has(id)) {
-            listStations.remove(getById(id));
-            Save();
+    public int remove(String id) {
+        for (int i = 0; i < listStations.size(); i++) {
+            if (listStations.get(i).ID.equals(id)) {
+                listStations.remove(i);
+                Save();
+                return i;
+            }
         }
+
+        return -1;
     }
 
-    public void clear(){
+    public void restore(DataRadioStation station, int pos) {
+        listStations.add(pos, station);
+        Save();
+    }
+
+    public void clear() {
         listStations.clear();
         Save();
     }
 
-    public boolean has(String id){
+    public boolean has(String id) {
         DataRadioStation station = getById(id);
         return station != null;
     }
 
-    public DataRadioStation[] getList(){
+    public DataRadioStation[] getList() {
         return listStations.toArray(new DataRadioStation[0]);
     }
 
-    void Load(){
+    void Load() {
         listStations.clear();
 
         SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(context);
         String str = sharedPref.getString(getSaveId(), null);
-        if (str != null){
-            DataRadioStation[] arr =DataRadioStation.DecodeJson(str);
+        if (str != null) {
+            DataRadioStation[] arr = DataRadioStation.DecodeJson(str);
             Collections.addAll(listStations, arr);
-        }else{
-            Log.w("SAVE","Load() no stations to load");
+        } else {
+            Log.w("SAVE", "Load() no stations to load");
         }
     }
 
-    void Save(){
+    void Save() {
         JSONArray arr = new JSONArray();
-        for (DataRadioStation station: listStations){
+        for (DataRadioStation station : listStations) {
             arr.put(station.toJson());
         }
 
         SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(context);
         SharedPreferences.Editor editor = sharedPref.edit();
         String str = arr.toString();
-        if(BuildConfig.DEBUG) { Log.d("SAVE","wrote: "+str); }
+        if (BuildConfig.DEBUG) {
+            Log.d("SAVE", "wrote: " + str);
+        }
         editor.putString(getSaveId(), str);
         editor.commit();
     }

--- a/app/src/main/java/net/programmierecke/radiodroid2/utils/RecyclerItemSwipeHelper.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/utils/RecyclerItemSwipeHelper.java
@@ -1,0 +1,63 @@
+package net.programmierecke.radiodroid2.utils;
+
+import android.graphics.Canvas;
+import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.helper.ItemTouchHelper;
+import android.view.View;
+
+public class RecyclerItemSwipeHelper<ViewHolderType extends SwipeableViewHolder> extends ItemTouchHelper.SimpleCallback {
+
+    public interface SwipeCallback<ViewHolderType> {
+        void onSwiped(ViewHolderType viewHolder, int direction);
+    }
+
+    private SwipeCallback<ViewHolderType> swipeListener;
+
+    public RecyclerItemSwipeHelper(int dragDirs, int swipeDirs, SwipeCallback<ViewHolderType> swipeListener) {
+        super(dragDirs, swipeDirs);
+        this.swipeListener = swipeListener;
+    }
+
+    @Override
+    public void onSelectedChanged(RecyclerView.ViewHolder viewHolder, int actionState) {
+        if (viewHolder != null) {
+            final View foregroundView = ((SwipeableViewHolder) viewHolder).getForegroundView();
+            getDefaultUIUtil().onSelected(foregroundView);
+        }
+    }
+
+    @Override
+    public void onChildDrawOver(Canvas c, RecyclerView recyclerView,
+                                RecyclerView.ViewHolder viewHolder, float dX, float dY,
+                                int actionState, boolean isCurrentlyActive) {
+        final View foregroundView = ((SwipeableViewHolder) viewHolder).getForegroundView();
+        getDefaultUIUtil().onDrawOver(c, recyclerView, foregroundView, dX, dY,
+                actionState, isCurrentlyActive);
+    }
+
+    @Override
+    public void clearView(RecyclerView recyclerView, RecyclerView.ViewHolder viewHolder) {
+        final View foregroundView = ((SwipeableViewHolder) viewHolder).getForegroundView();
+        getDefaultUIUtil().clearView(foregroundView);
+    }
+
+    @Override
+    public void onChildDraw(Canvas c, RecyclerView recyclerView,
+                            RecyclerView.ViewHolder viewHolder, float dX, float dY,
+                            int actionState, boolean isCurrentlyActive) {
+        final View foregroundView = ((SwipeableViewHolder) viewHolder).getForegroundView();
+
+        getDefaultUIUtil().onDraw(c, recyclerView, foregroundView, dX, dY,
+                actionState, isCurrentlyActive);
+    }
+
+    @Override
+    public boolean onMove(RecyclerView recyclerView, RecyclerView.ViewHolder viewHolder, RecyclerView.ViewHolder target) {
+        return true;
+    }
+
+    @Override
+    public void onSwiped(RecyclerView.ViewHolder viewHolder, int direction) {
+        swipeListener.onSwiped((ViewHolderType) viewHolder, direction);
+    }
+}

--- a/app/src/main/java/net/programmierecke/radiodroid2/utils/SwipeableViewHolder.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/utils/SwipeableViewHolder.java
@@ -1,0 +1,7 @@
+package net.programmierecke.radiodroid2.utils;
+
+import android.view.View;
+
+public interface SwipeableViewHolder {
+    View getForegroundView();
+}

--- a/app/src/main/res/layout/list_item_station.xml
+++ b/app/src/main/res/layout/list_item_station.xml
@@ -1,161 +1,169 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/LinearLayout1"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:descendantFocusability="blocksDescendants"
-    android:orientation="vertical">
+    android:background="@color/colorStationSwipeBackground"
+    android:descendantFocusability="blocksDescendants">
 
     <LinearLayout
-        android:id="@+id/layoutMain"
+        android:id="@+id/station_foreground"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:descendantFocusability="blocksDescendants"
-        android:minHeight="88dp">
-
-        <FrameLayout
-            android:layout_width="90dp"
-            android:layout_height="wrap_content"
-            android:measureAllChildren="true"
-            android:layout_gravity="center_vertical">
-
-        <ImageView
-            android:id="@+id/imageViewIcon"
-            android:layout_width="70dp"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center|start"
-            android:layout_marginLeft="5dp"
-            android:layout_marginStart="5dp"
-            android:layout_marginEnd="20dp" />
-
-        <ImageView
-            android:id="@+id/starredStatusIcon"
-            android:layout_width="30dp"
-            android:layout_height="30dp"
-            android:layout_gravity="top|end"
-            android:scaleType="fitCenter"
-            android:src="@drawable/ic_star_transparent_with_border_24dp"/>
-
-        </FrameLayout>
+        android:background="?android:colorBackground"
+        android:orientation="vertical">
 
         <LinearLayout
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:layout_weight="1"
-            android:orientation="vertical"
-            android:paddingBottom="8dp"
-            android:paddingStart="5dp"
-            android:paddingLeft="5dp"
-            android:paddingTop="8dp">
-
-            <TextView
-                android:id="@+id/textViewTitle"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:ellipsize="end"
-                android:maxLines="1"
-                android:textAppearance="@style/TextAppearance.AppCompat.Body2"/>
-
-            <TextView
-                android:id="@+id/textViewShortDescription"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:drawablePadding="4sp"
-                android:ellipsize="end"
-                android:maxLines="1"
-                android:minLines="1"
-                android:textAppearance="@style/TextAppearance.AppCompat.Body1"/>
-
-            <TextView
-                android:id="@+id/textViewTags"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:ellipsize="end"
-                android:maxLines="1"
-                android:minLines="1"
-                android:textAppearance="@style/TextAppearance.AppCompat.Body1"/>
-
-        </LinearLayout>
-
-        <ImageButton
-            android:id="@+id/buttonMore"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:layout_gravity="center"
-            android:background="@android:color/transparent"
-            android:contentDescription="@string/image_button_more"
-            android:minWidth="50dp"
-            android:padding="5dp"
-            app:srcCompat="@drawable/ic_expand_more_black_24dp"/>
-    </LinearLayout>
-
-    <LinearLayout
-        android:id="@+id/layoutDetails"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="16dp"
-        android:layout_marginLeft="16dp"
-        android:layout_marginRight="16dp"
-        android:layout_marginStart="16dp"
-        android:clickable="true"
-        android:descendantFocusability="blocksDescendants"
-        android:orientation="vertical">
-        <!--android:visibility="gone">-->
-
-        <net.programmierecke.radiodroid2.views.TagsView
-            android:id="@+id/viewTags"
+            android:id="@+id/layoutMain"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:lineSpacingMultiplier="1"
-            android:textSize="16sp"
-            app:cornerRadius="8dp"
-            app:tagBackgroundColor="#E0E0E0"
-            app:tagHeight="25sp"
-            app:textHorizontalPadding="8dp"
-            app:textVerticalMargin="4dp" />
+            android:descendantFocusability="blocksDescendants"
+            android:minHeight="88dp">
 
+            <FrameLayout
+                android:layout_width="90dp"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:measureAllChildren="true">
+
+                <ImageView
+                    android:id="@+id/imageViewIcon"
+                    android:layout_width="70dp"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center|start"
+                    android:layout_marginEnd="20dp"
+                    android:layout_marginLeft="5dp"
+                    android:layout_marginRight="20dp"
+                    android:layout_marginStart="5dp" />
+
+                <ImageView
+                    android:id="@+id/starredStatusIcon"
+                    android:layout_width="30dp"
+                    android:layout_height="30dp"
+                    android:layout_gravity="top|end"
+                    android:scaleType="fitCenter"
+                    app:srcCompat="@drawable/ic_star_transparent_with_border_24dp" />
+
+            </FrameLayout>
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:paddingBottom="8dp"
+                android:paddingLeft="5dp"
+                android:paddingStart="5dp"
+                android:paddingTop="8dp">
+
+                <TextView
+                    android:id="@+id/textViewTitle"
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:maxLines="1"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Body2" />
+
+                <TextView
+                    android:id="@+id/textViewShortDescription"
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:drawablePadding="4sp"
+                    android:ellipsize="end"
+                    android:maxLines="1"
+                    android:minLines="1"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
+
+                <TextView
+                    android:id="@+id/textViewTags"
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:maxLines="1"
+                    android:minLines="1"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
+
+            </LinearLayout>
+
+            <ImageButton
+                android:id="@+id/buttonMore"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_gravity="center"
+                android:background="@android:color/transparent"
+                android:contentDescription="@string/image_button_more"
+                android:minWidth="50dp"
+                android:padding="5dp"
+                app:srcCompat="@drawable/ic_expand_more_black_24dp" />
+        </LinearLayout>
 
         <LinearLayout
-            android:layout_width="wrap_content"
+            android:id="@+id/layoutDetails"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal">
+            android:layout_marginEnd="16dp"
+            android:layout_marginLeft="16dp"
+            android:layout_marginRight="16dp"
+            android:layout_marginStart="16dp"
+            android:clickable="true"
+            android:descendantFocusability="blocksDescendants"
+            android:orientation="vertical">
+            <!--android:visibility="gone">-->
 
-            <ImageButton
-                android:id="@+id/buttonStationWebLink"
-                style="@style/IconButton"
+            <net.programmierecke.radiodroid2.views.TagsView
+                android:id="@+id/viewTags"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:lineSpacingMultiplier="1"
+                android:textSize="16sp"
+                app:cornerRadius="8dp"
+                app:tagBackgroundColor="#E0E0E0"
+                app:tagHeight="25sp"
+                app:textHorizontalPadding="8dp"
+                app:textVerticalMargin="4dp" />
+
+
+            <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:contentDescription="@string/detail_weblink"
-                app:srcCompat="@drawable/ic_store_black_24dp" />
+                android:orientation="horizontal">
 
-            <ImageButton
-                android:id="@+id/buttonShare"
-                style="@style/IconButton"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:contentDescription="@string/detail_share"
-                app:srcCompat="@drawable/ic_share_24dp" />
+                <ImageButton
+                    android:id="@+id/buttonStationWebLink"
+                    style="@style/IconButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:contentDescription="@string/detail_weblink"
+                    app:srcCompat="@drawable/ic_store_black_24dp" />
 
-            <ImageButton
-                android:id="@+id/buttonBookmark"
-                style="@style/IconButton"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:contentDescription="@string/detail_star"
-                app:srcCompat="@drawable/ic_star_border_black_24dp" />
+                <ImageButton
+                    android:id="@+id/buttonShare"
+                    style="@style/IconButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:contentDescription="@string/detail_share"
+                    app:srcCompat="@drawable/ic_share_24dp" />
 
-            <ImageButton
-                android:id="@+id/buttonSetTimer"
-                style="@style/IconButton"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:contentDescription="@string/nav_item_alarm"
-                app:srcCompat="@drawable/ic_query_builder_black_24dp" />
+                <ImageButton
+                    android:id="@+id/buttonBookmark"
+                    style="@style/IconButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:contentDescription="@string/detail_star"
+                    app:srcCompat="@drawable/ic_star_border_black_24dp" />
+
+                <ImageButton
+                    android:id="@+id/buttonSetTimer"
+                    style="@style/IconButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:contentDescription="@string/nav_item_alarm"
+                    app:srcCompat="@drawable/ic_query_builder_black_24dp" />
+
+            </LinearLayout>
 
         </LinearLayout>
 
     </LinearLayout>
-
-</LinearLayout>
+</FrameLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,5 @@
     <color name="navigationBarColor">#000000</color>
     <color name="colorAccent">#1d6293</color>
     <color name="colorTabUnderline">#e0347f</color>
+    <color name="colorStationSwipeBackground">#ff4081</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,6 +95,9 @@
     <string name="notify_deleted_favorites">The favorites have been deleted.</string>
     <string name="notify_deleted_history">The history has been deleted.</string>
 
+    <string name="notify_station_removed_from_list">1 Removed</string>
+    <string name="action_station_removed_from_list_undo">UNDO</string>
+
     <string name="alert_delete_history">Do you really want to delete the history?</string>
     <string name="alert_delete_favorites">Do you really want to delete all favorites?</string>
     <string name="yes">Yes</string>


### PR DESCRIPTION
Changes:
- add optional enabling of 'Swipe to Remove' to ItemAdapterStation.
- add ability to restore removed station in StationSaveManager.
- remove the instantiation of FavouriteManager and HistoryManager every time they are needed.

Resolves #212.