### PR TITLE
Add option to change recording's file name format. Fix #273

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/PlayerService.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/PlayerService.java
@@ -220,7 +220,7 @@ public class PlayerService extends Service implements RadioPlayer.PlayerListener
                 RadioDroidApp radioDroidApp = (RadioDroidApp) getApplication();
                 RecordingsManager recordingsManager = radioDroidApp.getRecordingsManager();
 
-                recordingsManager.record(radioPlayer);
+                recordingsManager.record(PlayerService.this, radioPlayer);
 
                 sendBroadCast(PLAYER_SERVICE_META_UPDATE);
             }

--- a/app/src/main/java/net/programmierecke/radiodroid2/Utils.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/Utils.java
@@ -363,4 +363,24 @@ public class Utils {
         SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(context);
         return sharedPref.getBoolean("bottom_navigation", true);
     }
+
+    public static String formatStringWithNamedArgs(String format, Map<String, String> args) {
+	    StringBuilder builder = new StringBuilder(format);
+		for (Map.Entry<String, String> entry : args.entrySet()) {
+		    final String key = "${" + entry.getKey() + "}";
+		    int startIdx = 0;
+		    while (true) {
+                final int keyIdx = builder.indexOf(key, startIdx);
+
+                if (keyIdx == -1) {
+                    break;
+                }
+
+                builder.replace(keyIdx, keyIdx + key.length(), entry.getValue());
+                startIdx = keyIdx + entry.getValue().length();
+            }
+		}
+
+		return builder.toString();
+	}
 }

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/RadioPlayer.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/RadioPlayer.java
@@ -13,6 +13,7 @@ import android.util.Log;
 
 import net.programmierecke.radiodroid2.BuildConfig;
 import net.programmierecke.radiodroid2.HttpClient;
+import net.programmierecke.radiodroid2.Utils;
 import net.programmierecke.radiodroid2.data.ShoutcastInfo;
 import net.programmierecke.radiodroid2.data.StreamLiveInfo;
 import net.programmierecke.radiodroid2.players.exoplayer.ExoPlayerWrapper;
@@ -20,6 +21,8 @@ import net.programmierecke.radiodroid2.players.mediaplayer.MediaPlayerWrapper;
 import net.programmierecke.radiodroid2.recording.Recordable;
 import net.programmierecke.radiodroid2.recording.RecordableListener;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import okhttp3.OkHttpClient;
@@ -59,6 +62,8 @@ public class RadioPlayer implements PlayerWrapper.PlayListener, Recordable {
 
     private PlayerListener playerListener;
     private PlayState playState = PlayState.Idle;
+
+    private StreamLiveInfo lastLiveInfo;
 
     private CountDownTimer bufferCheckTimer = new CountDownTimer(Long.MAX_VALUE, 2000) {
         @Override
@@ -209,8 +214,19 @@ public class RadioPlayer implements PlayerWrapper.PlayListener, Recordable {
     }
 
     @Override
-    public String getTitle() {
-        return streamName;
+    public Map<String, String> getNameFormattingArgs() {
+        Map<String, String> args = new HashMap<>();
+        args.put("station", Utils.sanitizeName(streamName));
+
+        if (lastLiveInfo != null) {
+            args.put("artist", Utils.sanitizeName(lastLiveInfo.getArtist()));
+            args.put("track", Utils.sanitizeName(lastLiveInfo.getTrack()));
+        } else {
+            args.put("artist", "-");
+            args.put("track", "-");
+        }
+
+        return args;
     }
 
     @Override
@@ -272,6 +288,7 @@ public class RadioPlayer implements PlayerWrapper.PlayListener, Recordable {
 
     @Override
     public void onDataSourceStreamLiveInfo(StreamLiveInfo liveInfo) {
+        lastLiveInfo = liveInfo;
         playerListener.foundLiveStreamInfo(liveInfo);
     }
 }

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/ExoPlayerWrapper.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/ExoPlayerWrapper.java
@@ -41,6 +41,8 @@ import net.programmierecke.radiodroid2.data.StreamLiveInfo;
 import net.programmierecke.radiodroid2.players.PlayerWrapper;
 import net.programmierecke.radiodroid2.players.RadioPlayer;
 
+import java.util.Map;
+
 import okhttp3.OkHttpClient;
 
 public class ExoPlayerWrapper implements PlayerWrapper, IcyDataSource.IcyDataSourceListener {
@@ -239,7 +241,7 @@ public class ExoPlayerWrapper implements PlayerWrapper, IcyDataSource.IcyDataSou
     }
 
     @Override
-    public String getTitle() {
+    public Map<String, String> getNameFormattingArgs() {
         return null;
     }
 

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/mediaplayer/MediaPlayerWrapper.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/mediaplayer/MediaPlayerWrapper.java
@@ -16,6 +16,7 @@ import net.programmierecke.radiodroid2.players.RadioPlayer;
 import net.programmierecke.radiodroid2.recording.RecordableListener;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import okhttp3.OkHttpClient;
@@ -210,7 +211,7 @@ public class MediaPlayerWrapper implements PlayerWrapper, StreamProxyListener {
     }
 
     @Override
-    public String getTitle() {
+    public Map<String, String> getNameFormattingArgs() {
         return null;
     }
 

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/mediaplayer/StreamProxy.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/mediaplayer/StreamProxy.java
@@ -337,8 +337,8 @@ public class StreamProxy implements Recordable {
     }
 
     @Override
-    public String getTitle() {
-        return "";
+    public Map<String, String> getNameFormattingArgs() {
+        return null;
     }
 
     @Override

--- a/app/src/main/java/net/programmierecke/radiodroid2/recording/Recordable.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/recording/Recordable.java
@@ -2,6 +2,8 @@ package net.programmierecke.radiodroid2.recording;
 
 import android.support.annotation.NonNull;
 
+import java.util.Map;
+
 public interface Recordable {
 
     boolean canRecord();
@@ -12,6 +14,6 @@ public interface Recordable {
 
     boolean isRecording();
 
-    String getTitle();
+    Map<String, String> getNameFormattingArgs();
     String getExtension();
 }

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -104,6 +104,14 @@
     <string name="settings_warn_no_wifi_on">Предупреждать при начале проигрывания без Wifi соединения</string>
     <string name="settings_warn_no_wifi_off">Не предупреждать при проигрывании без Wifi соединения</string>
 
+    <string name="settings_recordings">Записи</string>
+    <string name="settings_record_name_formatting">Формат имени</string>
+
+    <string name="settings_record_name_formatting_default_display">станция+артист+трек+\u200bдата+\u200bвремя</string>
+    <string name="settings_record_name_formatting_1_display">станция+артист+\u200bтрек</string>
+    <string name="settings_record_name_formatting_2_display">станция+дата+\u200bвремя</string>
+    <string name="settings_record_name_formatting_3_display">номер+станция+\u200bдата</string>
+
     <string name="notify_pre_play">Подключение</string>
     <string name="notify_play">Играет</string>
     <string name="notify_paused">Приостановлена</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -107,10 +107,10 @@
     <string name="settings_recordings">Записи</string>
     <string name="settings_record_name_formatting">Формат имени</string>
 
-    <string name="settings_record_name_formatting_default_display">станция+артист+трек+\u200bдата+\u200bвремя</string>
-    <string name="settings_record_name_formatting_1_display">станция+артист+\u200bтрек</string>
-    <string name="settings_record_name_formatting_2_display">станция+дата+\u200bвремя</string>
-    <string name="settings_record_name_formatting_3_display">номер+станция+\u200bдата</string>
+    <string name="settings_record_name_formatting_default_display">станция_артист_трек_\u200bдата_\u200bвремя</string>
+    <string name="settings_record_name_formatting_1_display">станция_артист_\u200bтрек</string>
+    <string name="settings_record_name_formatting_2_display">станция_дата_\u200bвремя</string>
+    <string name="settings_record_name_formatting_3_display">номер_станция_\u200bдата</string>
 
     <string name="notify_pre_play">Подключение</string>
     <string name="notify_play">Играет</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -47,4 +47,18 @@
         <item>@string/theme_dark</item>
     </string-array>
 
+    <string-array name="settings_record_name_formatting_list">
+        <item>@string/settings_record_name_formatting_default</item>
+        <item>@string/settings_record_name_formatting_1</item>
+        <item>@string/settings_record_name_formatting_2</item>
+        <item>@string/settings_record_name_formatting_3</item>
+    </string-array>
+
+    <string-array name="settings_record_name_formatting_list_display">
+        <item>@string/settings_record_name_formatting_default_display</item>
+        <item>@string/settings_record_name_formatting_1_display</item>
+        <item>@string/settings_record_name_formatting_2_display</item>
+        <item>@string/settings_record_name_formatting_3_display</item>
+    </string-array>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -109,6 +109,19 @@
     <string name="settings_warn_no_wifi_on">Warn when playing without Wifi connection</string>
     <string name="settings_warn_no_wifi_off">No warning when not on Wifi connection</string>
 
+    <string name="settings_recordings">Recordings</string>
+    <string name="settings_record_name_formatting">Name formatting</string>
+
+    <string name="settings_record_name_formatting_default" translatable="false">${station}+${artist}+${track}+${date}+${time}</string>
+    <string name="settings_record_name_formatting_1" translatable="false">${station}+${artist}+${track}</string>
+    <string name="settings_record_name_formatting_2" translatable="false">${station}+${date}+${time}</string>
+    <string name="settings_record_name_formatting_3" translatable="false">${index}+${station}+${date}</string>
+
+    <string name="settings_record_name_formatting_default_display">station+artist+track+\u200bdate+\u200btime</string>
+    <string name="settings_record_name_formatting_1_display">station+artist+\u200btrack</string>
+    <string name="settings_record_name_formatting_2_display">station+date+\u200btime</string>
+    <string name="settings_record_name_formatting_3_display">index+station+\u200bdate</string>
+
     <string name="notify_pre_play">Connecting</string>
     <string name="notify_play">Playing</string>
     <string name="notify_paused">Paused</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -112,15 +112,15 @@
     <string name="settings_recordings">Recordings</string>
     <string name="settings_record_name_formatting">Name formatting</string>
 
-    <string name="settings_record_name_formatting_default" translatable="false">${station}+${artist}+${track}+${date}+${time}</string>
-    <string name="settings_record_name_formatting_1" translatable="false">${station}+${artist}+${track}</string>
-    <string name="settings_record_name_formatting_2" translatable="false">${station}+${date}+${time}</string>
-    <string name="settings_record_name_formatting_3" translatable="false">${index}+${station}+${date}</string>
+    <string name="settings_record_name_formatting_default" translatable="false">${station}_${artist}_${track}_${date}_${time}</string>
+    <string name="settings_record_name_formatting_1" translatable="false">${station}_${artist}_${track}</string>
+    <string name="settings_record_name_formatting_2" translatable="false">${station}_${date}_${time}</string>
+    <string name="settings_record_name_formatting_3" translatable="false">${index}_${station}_${date}</string>
 
-    <string name="settings_record_name_formatting_default_display">station+artist+track+\u200bdate+\u200btime</string>
-    <string name="settings_record_name_formatting_1_display">station+artist+\u200btrack</string>
-    <string name="settings_record_name_formatting_2_display">station+date+\u200btime</string>
-    <string name="settings_record_name_formatting_3_display">index+station+\u200bdate</string>
+    <string name="settings_record_name_formatting_default_display">station_artist_track_\u200bdate_\u200btime</string>
+    <string name="settings_record_name_formatting_1_display">station_artist_\u200btrack</string>
+    <string name="settings_record_name_formatting_2_display">station_date_\u200btime</string>
+    <string name="settings_record_name_formatting_3_display">index_station_\u200bdate</string>
 
     <string name="notify_pre_play">Connecting</string>
     <string name="notify_play">Playing</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -21,9 +21,9 @@
             android:title="@string/settings_compact_style" />
 
         <CheckBoxPreference
-                android:key="bottom_navigation"
-                android:defaultValue="true"
-                android:title="@string/settings_bottom_navigation" />
+            android:defaultValue="true"
+            android:key="bottom_navigation"
+            android:title="@string/settings_bottom_navigation" />
 
     </PreferenceCategory>
 
@@ -60,12 +60,14 @@
             android:title="@string/settings_auto_favorite" />
 
         <CheckBoxPreference
+            android:defaultValue="false"
             android:key="show_broken"
             android:summaryOff="@string/settings_show_broken_off"
             android:summaryOn="@string/settings_show_broken_on"
             android:title="@string/settings_show_broken" />
 
         <CheckBoxPreference
+            android:defaultValue="false"
             android:key="single_use_tags"
             android:summaryOff="@string/settings_single_use_tags_desc_off"
             android:summaryOn="@string/settings_single_use_tags_desc_on"
@@ -81,6 +83,7 @@
             android:title="@string/settings_play_external" />
 
         <CheckBoxPreference
+            android:defaultValue="false"
             android:key="warn_no_wifi"
             android:summaryOff="@string/settings_warn_no_wifi_off"
             android:summaryOn="@string/settings_warn_no_wifi_on"
@@ -115,11 +118,20 @@
 
     </PreferenceCategory>
 
-    <PreferenceCategory
-        android:title="@string/settings_mpd">
+    <PreferenceCategory android:title="@string/settings_recordings">
+        <ListPreference
+            android:defaultValue="@string/settings_record_name_formatting_default"
+            android:entries="@array/settings_record_name_formatting_list_display"
+            android:entryValues="@array/settings_record_name_formatting_list"
+            android:key="record_name_formatting"
+            android:summary="%s"
+            android:title="@string/settings_record_name_formatting" />
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="@string/settings_mpd">
         <Preference
-            android:title="@string/settings_view_mpd_servers"
-            android:key="mpd_servers_viewer" />
+            android:key="mpd_servers_viewer"
+            android:title="@string/settings_view_mpd_servers" />
     </PreferenceCategory>
 
     <PreferenceCategory
@@ -129,38 +141,37 @@
             android:defaultValue="4"
             android:key="stream_connect_timeout"
             android:maxLength="2"
-            android:title="@string/settings_connect_timeout"
-            android:summary="@string/settings_seconds_format"/>
+            android:summary="@string/settings_seconds_format"
+            android:title="@string/settings_connect_timeout" />
         <net.programmierecke.radiodroid2.views.IntEditTextPreference
             android:defaultValue="10"
             android:key="stream_read_timeout"
             android:maxLength="2"
-            android:title="@string/settings_read_timeout"
-            android:summary="@string/settings_seconds_format"/>
+            android:summary="@string/settings_seconds_format"
+            android:title="@string/settings_read_timeout" />
         <net.programmierecke.radiodroid2.views.IntEditTextPreference
             android:defaultValue="99999999"
             android:key="settings_retry_timeout"
             android:maxLength="8"
-            android:title="@string/settings_retry_timeout"
-            android:summary="@string/settings_seconds_format"/>
+            android:summary="@string/settings_seconds_format"
+            android:title="@string/settings_retry_timeout" />
         <net.programmierecke.radiodroid2.views.IntEditTextPreference
             android:defaultValue="0"
             android:key="settings_retry_delay"
             android:maxLength="8"
-            android:title="@string/settings_retry_delay"
-            android:summary="@string/settings_milliseconds_format"/>
+            android:summary="@string/settings_milliseconds_format"
+            android:title="@string/settings_retry_delay" />
     </PreferenceCategory>
 
-    <PreferenceCategory
-            android:title="@string/settings_other">
+    <PreferenceCategory android:title="@string/settings_other">
 
         <Preference
-                android:title="@string/settings_statistics"
-                android:key="show_statistics" />
+            android:key="show_statistics"
+            android:title="@string/settings_statistics" />
 
         <Preference
-                android:title="@string/settings_about"
-                android:key="show_about" />
+            android:key="show_about"
+            android:title="@string/settings_about" />
 
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
Now there is an option with predefined name formats for recordings. By default the first option is selected (the most verbose one). Fixes regression #273 
![radio_droid_option_name_formatting](https://user-images.githubusercontent.com/3993671/34907246-453177f6-f884-11e7-84b7-26c65f671937.jpg)

I have decided to make format selection localized. Also the delimiter between name parts is '+' because usage of underscores makes a salad from words in a file name (in my opinion).

Ultimately there should be a user input for format but I've got lazy.