### PR TITLE
ProgressBar, current station, bug fix

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/ActivityMain.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/ActivityMain.java
@@ -196,6 +196,8 @@ public class ActivityMain extends AppCompatActivity implements SearchView.OnQuer
         else
             fragmentTransaction.replace(R.id.containerView, f).addToBackStack(backStackTag).commit();
 
+        // User selected a menuItem. Let's hide progressBar
+        sendBroadcast(new Intent(ActivityMain.ACTION_HIDE_LOADING));
         invalidateOptionsMenu();
         checkMenuItems();
 

--- a/app/src/main/java/net/programmierecke/radiodroid2/ActivityMain.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/ActivityMain.java
@@ -222,7 +222,7 @@ public class ActivityMain extends AppCompatActivity implements SearchView.OnQuer
         if(Utils.bottomNavigationEnabled(this)) {
             // I'm giving 3 seconds on making a choice
             if (lastExitTry != null && new Date().getTime() < lastExitTry.getTime() + 3 * 1000) {
-                PlayerServiceUtil.stop();
+                PlayerServiceUtil.shutdownService();
                 finish();
             }
             else {
@@ -333,6 +333,7 @@ public class ActivityMain extends AppCompatActivity implements SearchView.OnQuer
             Log.d(TAG, "RESUMED");
         }
 
+        PlayerServiceUtil.bind(this);
         CastHandler.onResume();
         MPDClient.StartDiscovery(this, this);
     }

--- a/app/src/main/java/net/programmierecke/radiodroid2/ActivityMain.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/ActivityMain.java
@@ -28,7 +28,6 @@ import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.ProgressBar;
 import android.widget.SeekBar;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -618,14 +617,10 @@ public class ActivityMain extends AppCompatActivity implements SearchView.OnQuer
 
     // Loading listener
     private void showLoadingIcon() {
-        MenuItem menuItem = getToolbar().getMenu().findItem(R.id.action_loading);
-        menuItem.setActionView(new ProgressBar(this));
-        menuItem.setVisible(true);
+        findViewById(R.id.progressBarLoading).setVisibility(View.VISIBLE);
     }
     private void hideLoadingIcon() {
-        MenuItem menuItem = getToolbar().getMenu().findItem(R.id.action_loading);
-        menuItem.setActionView(null);
-        menuItem.setVisible(false);
+        findViewById(R.id.progressBarLoading).setVisibility(View.GONE);
     }
 
     private void changeTimer() {

--- a/app/src/main/java/net/programmierecke/radiodroid2/ActivityRadioStationDetail.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/ActivityRadioStationDetail.java
@@ -2,7 +2,6 @@ package net.programmierecke.radiodroid2;
 
 import java.util.Locale;
 
-import android.app.ProgressDialog;
 import android.app.TimePickerDialog;
 import android.content.Intent;
 import android.net.Uri;
@@ -22,7 +21,6 @@ import android.widget.TimePicker;
 import net.programmierecke.radiodroid2.data.DataRadioStation;
 
 public class ActivityRadioStationDetail extends AppCompatActivity implements TimePickerDialog.OnTimeSetListener {
-	private ProgressDialog itsProgressLoading;
 	private DataRadioStation itsStation;
 	private MenuItem m_Menu_Star;
 	private MenuItem m_Menu_UnStar;
@@ -49,7 +47,7 @@ public class ActivityRadioStationDetail extends AppCompatActivity implements Tim
 
 		UpdateMenu();
 
-		itsProgressLoading = ProgressDialog.show(ActivityRadioStationDetail.this, "", getResources().getText(R.string.progress_loading));
+		getApplicationContext().sendBroadcast(new Intent(ActivityMain.ACTION_SHOW_LOADING));
 		new AsyncTask<Void, Void, String>() {
 			@Override
 			protected String doInBackground(Void... params) {
@@ -66,7 +64,7 @@ public class ActivityRadioStationDetail extends AppCompatActivity implements Tim
 						}
 					}
 				}
-				itsProgressLoading.dismiss();
+				getApplicationContext().sendBroadcast(new Intent(ActivityMain.ACTION_HIDE_LOADING));
 				super.onPostExecute(result);
 			}
 

--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentBase.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentBase.java
@@ -1,7 +1,7 @@
 package net.programmierecke.radiodroid2;
 
-import android.app.ProgressDialog;
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.AsyncTask;
 import android.os.Bundle;
@@ -16,7 +16,6 @@ import java.util.HashMap;
 public class FragmentBase extends Fragment {
     private static final String TAG = "FragmentBase";
 
-    private ProgressDialog itsProgressLoading;
     private String url;
     private String urlResult;
 
@@ -76,7 +75,7 @@ public class FragmentBase extends Fragment {
             String cache = Utils.getCacheFile(getActivity(), url);
             if (cache == null || forceUpdate) {
                 if (getContext() != null && displayProgress) {
-                    itsProgressLoading = ProgressDialog.show(getContext(), "", getActivity().getString(R.string.progress_loading));
+                    getActivity().sendBroadcast(new Intent(ActivityMain.ACTION_SHOW_LOADING));
                 }
                 new AsyncTask<Void, Void, String>() {
                     @Override
@@ -91,10 +90,7 @@ public class FragmentBase extends Fragment {
                     @Override
                     protected void onPostExecute(String result) {
                         DownloadFinished();
-                        if (itsProgressLoading != null) {
-                            itsProgressLoading.dismiss();
-                            itsProgressLoading = null;
-                        }
+                        getActivity().sendBroadcast(new Intent(ActivityMain.ACTION_HIDE_LOADING));
                         if (BuildConfig.DEBUG) {
                             Log.d(TAG, "Download url finished:" + url);
                         }

--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentBase.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentBase.java
@@ -75,7 +75,7 @@ public class FragmentBase extends Fragment {
             String cache = Utils.getCacheFile(getActivity(), url);
             if (cache == null || forceUpdate) {
                 if (getContext() != null && displayProgress) {
-                    getActivity().sendBroadcast(new Intent(ActivityMain.ACTION_SHOW_LOADING));
+                    getContext().sendBroadcast(new Intent(ActivityMain.ACTION_SHOW_LOADING));
                 }
                 new AsyncTask<Void, Void, String>() {
                     @Override
@@ -90,7 +90,8 @@ public class FragmentBase extends Fragment {
                     @Override
                     protected void onPostExecute(String result) {
                         DownloadFinished();
-                        getActivity().sendBroadcast(new Intent(ActivityMain.ACTION_HIDE_LOADING));
+                        if(getContext() != null)
+                            getContext().sendBroadcast(new Intent(ActivityMain.ACTION_HIDE_LOADING));
                         if (BuildConfig.DEBUG) {
                             Log.d(TAG, "Download url finished:" + url);
                         }

--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentPlayer.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentPlayer.java
@@ -39,8 +39,6 @@ public class FragmentPlayer extends Fragment {
 		// Inflate the layout for this fragment
 		View view = inflater.inflate(R.layout.layout_player_status, container, false);
 
-        PlayerServiceUtil.bind(getContext());
-
         IntentFilter filter = new IntentFilter();
 
         filter.addAction(PlayerService.PLAYER_SERVICE_TIMER_UPDATE);
@@ -216,7 +214,6 @@ public class FragmentPlayer extends Fragment {
 			t.interrupt();
 		}
 		super.onDestroy();
-		PlayerServiceUtil.unBind(getContext());
 		if (updateUIReciver != null) {
 			getContext().unregisterReceiver(updateUIReciver);
 			updateUIReciver = null;

--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentPlayer.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentPlayer.java
@@ -1,6 +1,5 @@
 package net.programmierecke.radiodroid2;
 
-import android.app.ProgressDialog;
 import android.content.*;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
@@ -20,7 +19,6 @@ import net.programmierecke.radiodroid2.data.StreamLiveInfo;
 import static net.programmierecke.radiodroid2.ActivityMain.FRAGMENT_FROM_BACKSTACK;
 
 public class FragmentPlayer extends Fragment {
-	ProgressDialog itsProgressLoading;
 	TextView aTextViewName;
 	ImageButton buttonPause;
 	private BroadcastReceiver updateUIReciver;

--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentServerInfo.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentServerInfo.java
@@ -45,7 +45,8 @@ public class FragmentServerInfo extends Fragment implements IFragmentRefreshable
 
             @Override
             protected void onPostExecute(String result) {
-                getContext().sendBroadcast(new Intent(ActivityMain.ACTION_HIDE_LOADING));
+                if(getContext() != null)
+                    getContext().sendBroadcast(new Intent(ActivityMain.ACTION_HIDE_LOADING));
                 if (result != null) {
                     itemAdapterStatistics.clear();
                     DataStatistics[] items = DataStatistics.DecodeJson(result);

--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentServerInfo.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentServerInfo.java
@@ -1,6 +1,6 @@
 package net.programmierecke.radiodroid2;
 
-import android.app.ProgressDialog;
+import android.content.Intent;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -17,7 +17,6 @@ import net.programmierecke.radiodroid2.interfaces.IFragmentRefreshable;
 
 public class FragmentServerInfo extends Fragment implements IFragmentRefreshable {
     private ItemAdapterStatistics itemAdapterStatistics;
-    private ProgressDialog itsProgressLoading;
 
     @Nullable
     @Override
@@ -37,7 +36,7 @@ public class FragmentServerInfo extends Fragment implements IFragmentRefreshable
     }
 
     void Download(final boolean forceUpdate){
-        itsProgressLoading = ProgressDialog.show(getActivity(), "", getActivity().getString(R.string.progress_loading));
+        getContext().sendBroadcast(new Intent(ActivityMain.ACTION_SHOW_LOADING));
         new AsyncTask<Void, Void, String>() {
             @Override
             protected String doInBackground(Void... params) {
@@ -46,7 +45,7 @@ public class FragmentServerInfo extends Fragment implements IFragmentRefreshable
 
             @Override
             protected void onPostExecute(String result) {
-                itsProgressLoading.dismiss();
+                getContext().sendBroadcast(new Intent(ActivityMain.ACTION_HIDE_LOADING));
                 if (result != null) {
                     itemAdapterStatistics.clear();
                     DataStatistics[] items = DataStatistics.DecodeJson(result);

--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentTabs.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentTabs.java
@@ -59,14 +59,15 @@ public class FragmentTabs extends Fragment implements IFragmentRefreshable, IFra
 
         /*
          * Now , this is a workaround ,
-         * The setupWithViewPager dose't works without the runnable .
+         * The setupWithViewPager doesn't works without the runnable .
          * Maybe a Support Library Bug .
          */
 
         tabLayout.post(new Runnable() {
             @Override
             public void run() {
-                tabLayout.setupWithViewPager(viewPager);
+                if(getContext() != null)
+                    tabLayout.setupWithViewPager(viewPager);
             }
         });
 

--- a/app/src/main/java/net/programmierecke/radiodroid2/PlayerServiceUtil.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/PlayerServiceUtil.java
@@ -179,6 +179,17 @@ public class PlayerServiceUtil {
         return null;
     }
 
+    public static String getStationId() {
+        if (itsPlayerService != null) {
+            try {
+                return itsPlayerService.getCurrentStationID();
+            } catch (RemoteException e) {
+                Log.e("", "" + e);
+            }
+        }
+        return null;
+    }
+
     public static String getStationName() {
         if (itsPlayerService != null) {
             try {

--- a/app/src/main/java/net/programmierecke/radiodroid2/Utils.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/Utils.java
@@ -3,7 +3,6 @@ package net.programmierecke.radiodroid2;
 import android.Manifest;
 import android.app.Activity;
 import android.app.AlertDialog;
-import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -207,7 +206,7 @@ public class Utils {
 	}
 
 	private static void playInternal(final DataRadioStation station, final Context context, final boolean external) {
-		final ProgressDialog itsProgressLoading = ProgressDialog.show(context, "", context.getResources().getText(R.string.progress_loading));
+        context.sendBroadcast(new Intent(ActivityMain.ACTION_SHOW_LOADING));
 		new AsyncTask<Void, Void, String>() {
 			@Override
 			protected String doInBackground(Void... params) {
@@ -216,7 +215,7 @@ public class Utils {
 
 			@Override
 			protected void onPostExecute(String result) {
-				itsProgressLoading.dismiss();
+                context.sendBroadcast(new Intent(ActivityMain.ACTION_HIDE_LOADING));
 
 				if (result != null) {
 					boolean externalActive = false;

--- a/app/src/main/res/layout/layout_main.xml
+++ b/app/src/main/res/layout/layout_main.xml
@@ -18,7 +18,19 @@
         android:minHeight="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
         android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-        app:popupTheme="@style/ThemeOverlay.AppCompat.Light"/>
+        app:popupTheme="@style/ThemeOverlay.AppCompat.Light">
+
+        <ProgressBar
+                android:id="@+id/progressBarLoading"
+                android:layout_width="34dp"
+                android:layout_height="34dp"
+                android:layout_marginLeft="22dp"
+                android:layout_marginStart="22dp"
+                android:indeterminate="true"
+                android:theme="@style/ProgressBarCircle"
+                android:visibility="gone"/>
+
+    </android.support.v7.widget.Toolbar>
 
     <android.support.v7.app.MediaRouteButton
         android:id="@+id/media_route_button"

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -3,6 +3,11 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
+            android:id="@+id/action_loading"
+            android:visible="false"
+            app:showAsAction="always" />
+
+    <item
         android:id="@+id/action_search"
         android:title="@string/action_search"
         android:icon="@drawable/ic_search_24dp"

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -3,11 +3,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
-            android:id="@+id/action_loading"
-            android:visible="false"
-            app:showAsAction="always" />
-
-    <item
         android:id="@+id/action_search"
         android:title="@string/action_search"
         android:icon="@drawable/ic_search_24dp"

--- a/app/src/main/res/values/attrs_theme.xml
+++ b/app/src/main/res/values/attrs_theme.xml
@@ -13,4 +13,6 @@
     <attr name="colorTabUnderline" format="reference"/>
 
     <attr name="iconsInItemBackgroundColor" format="reference" />
+
+    <attr name="colorAccentMy" format="reference" />
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -34,6 +34,9 @@
         <item name="colorTabUnderline">@color/colorTabUnderline</item>
 
         <item name="iconsInItemBackgroundColor">@color/iconsInItemBackgroundColor</item>
+
+        <!-- workaround for lower API -->
+        <item name="colorAccentMy">@color/colorAccent</item>
     </style>
 
     <style name="MyMaterialTheme.Base.Dark" parent="Theme.AppCompat">
@@ -64,6 +67,9 @@
         <item name="colorTabUnderline">@color/colorTabUnderlineDark</item>
 
         <item name="iconsInItemBackgroundColor">@color/iconsInItemBackgroundColorDark</item>
+
+        <!-- workaround for lower API -->
+        <item name="colorAccentMy">@color/colorAccentDark</item>
     </style>
 
     <style name="IconButton" parent="Base.Widget.AppCompat.Button">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -98,4 +98,8 @@
         <item name="android:windowBackground">@color/windowBackgroundDark</item>
     </style>
 
+    <style name="ProgressBarCircle" parent="Widget.AppCompat.ProgressBar">
+        <item name="colorAccent">@android:color/white</item>
+
+    </style>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -8,7 +8,8 @@
             android:entries="@array/theme_entries"
             android:entryValues="@array/theme_values"
             android:key="theme_name"
-            android:title="@string/settings_theme_selection_title" />
+            android:title="@string/settings_theme_selection_title"
+            android:summary="%s"/>
 
         <CheckBoxPreference
             android:defaultValue="false"


### PR DESCRIPTION
- made circular progressBar which replaces old progress implementation. It is not blocking UI now.
- current station will be highlighted. closes #243
- fixed annoying bug. You can reproduce it:
open an app without tapping on play. Turn off a screen. Then turn it on. Tap on play. Change screen orientation to landscape. Service will be dead without music. 
- added summary in settings for theme selection.