### PR TITLE
Fix leaking intent receiver in ItemAdapterStation. Fix #290

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentHistory.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentHistory.java
@@ -110,4 +110,10 @@ public class FragmentHistory extends Fragment {
 
         return view;
     }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        rvStations.setAdapter(null);
+    }
 }

--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentStarred.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentStarred.java
@@ -95,4 +95,10 @@ public class FragmentStarred extends Fragment implements IAdapterRefreshable {
 
         return view;
     }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        rvStations.setAdapter(null);
+    }
 }

--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentStations.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentStations.java
@@ -125,6 +125,12 @@ public class FragmentStations extends FragmentBase {
     }
 
     @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        rvStations.setAdapter(null);
+    }
+
+    @Override
     protected void DownloadFinished() {
         if (swipeRefreshLayout != null) {
             swipeRefreshLayout.setRefreshing(false);


### PR DESCRIPTION
Force to call onDetachedFromRecyclerView for adapter when view which use it being destroyed. Without this onDetachedFromRecyclerView may be not called in some situations. 