### PR TITLE
Red color for station name while recording a station and MPD timeout

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentPlayer.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentPlayer.java
@@ -10,6 +10,7 @@ import android.support.v7.preference.PreferenceManager;
 import android.support.v7.widget.Toolbar;
 import android.text.TextUtils;
 import android.util.Log;
+import android.util.TypedValue;
 import android.view.*;
 import android.widget.*;
 
@@ -231,12 +232,18 @@ public class FragmentPlayer extends Fragment {
 		}
 
 		buttonRecord = (ImageButton) getActivity().findViewById(R.id.buttonRecord);
+		TypedValue tv = new TypedValue();
+		getContext().getTheme().resolveAttribute(R.attr.colorAccentMy, tv, true);
+
 		if (PlayerServiceUtil.isRecording()) {
 			buttonRecord.setImageResource(R.drawable.ic_stop_recording);
+			aTextViewName.setTextColor(getResources().getColor(R.color.startRecordingColor));
 		} else if (android.os.Environment.getExternalStorageDirectory().canWrite()) {
 			buttonRecord.setImageResource(R.drawable.ic_start_recording);
+			aTextViewName.setTextColor(tv.data);
 		} else {
 			buttonRecord.setImageResource(R.drawable.ic_fiber_manual_record_black_50dp);
+			aTextViewName.setTextColor(tv.data);
 		}
 
 		if(BuildConfig.DEBUG) { Log.d("ARR","UpdateOutput()"); }

--- a/app/src/main/java/net/programmierecke/radiodroid2/MPDClient.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/MPDClient.java
@@ -135,8 +135,10 @@ public class MPDClient {
         try {
             if(BuildConfig.DEBUG) { Log.d(TAG, "Check connection..."); }
             Socket s = new Socket();
-            // If you'll create the socket with default constructor new Socket(hostname, port) you will get 3 min timeout if the server is unreachable
-            s.connect(new InetSocketAddress(mpd_hostname, mpd_port), 5*1000);
+            // Timeout for local addresses should be as low as possible. Or you'll be waiting many seconds for a couple of servers if one (or more) of them will be unreachable
+            int timeout = mpd_hostname.startsWith("192.168.") || mpd_hostname.startsWith("127.0.") || mpd_hostname.startsWith("localhost") || mpd_hostname.startsWith("10.") || mpd_hostname.contains(".local")? 500 : 3*1000;
+			// If you'll create the socket with default constructor new Socket(hostname, port) you will get 3 min timeout if the server is unreachable
+			s.connect(new InetSocketAddress(mpd_hostname, mpd_port), timeout);
             BufferedReader reader = new BufferedReader(new InputStreamReader(s.getInputStream()));
             BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(s.getOutputStream()));
             String info = reader.readLine();

--- a/app/src/main/java/net/programmierecke/radiodroid2/recording/RecordingsManager.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/recording/RecordingsManager.java
@@ -21,6 +21,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -165,6 +166,15 @@ public class RecordingsManager {
                 dr.Time = new Date(f.lastModified());
                 list.add(dr);
             }
+
+            Collections.sort(list, new Comparator<DataRecording>() {
+                @Override
+                public int compare(DataRecording o1, DataRecording o2) {
+                    if(o1.Time.getTime() > o2.Time.getTime()) return 1;
+                    else if(o1.Time.getTime() < o2.Time.getTime()) return -1;
+                    else return 0;
+                }
+            });
         } else {
             Log.e(TAG, "could not enumerate files in recordings directory");
         }

--- a/app/src/main/res/drawable/ic_start_recording.xml
+++ b/app/src/main/res/drawable/ic_start_recording.xml
@@ -6,6 +6,6 @@
         android:viewportHeight="22">
 
     <path
-            android:fillColor="#f33"
+            android:fillColor="@color/startRecordingColor"
             android:pathData="M11,0C4.926,0,0,4.926,0,11s4.926,11,11,11s11-4.926,11-11S17.074,0,11,0z" />
 </vector>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -36,4 +36,6 @@
 
     <color name="iconsInItemBackgroundColor">@android:color/black</color>
     <color name="iconsInItemBackgroundColorDark">@android:color/white</color>
+
+    <color name="startRecordingColor">#ff3333</color>
 </resources>


### PR DESCRIPTION
- added red color for station name textView while user is recording a station. Suggested here: #291 but it looks different. Icon at the left side of the name (as suggested) will make a code less maintainable (xml layout and java file should be changed hard).
- timeout for local MPD servers now equals to 0.5 sec and 3 sec for remote servers. This will help to prevent long time waiting for connection while some of the servers are not reachable. 
- recordings are sorted by date