### PR TITLE
Empty favorites, click trend icon and NPE

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentStations.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentStations.java
@@ -72,7 +72,9 @@ public class FragmentStations extends FragmentBase {
         }
 
         ItemAdapterStation adapter = (ItemAdapterStation) rvStations.getAdapter();
-        adapter.updateList(null, filteredStationsList);
+        if (adapter != null) {
+            adapter.updateList(null, filteredStationsList);
+        }
     }
 
     @Override

--- a/app/src/main/java/net/programmierecke/radiodroid2/MPDClient.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/MPDClient.java
@@ -41,9 +41,10 @@ public class MPDClient {
         isPlaying = false;
         if (stateChangeListener != null)
             stateChangeListener.changed();
-        // Don't stop playback in that case. User can listen via MPD and via the app
-        // User can stop playback via MPD with pause button
-        //Stop(context);
+        /*
+         * Don't stop playback in that case. User can listen via MPD and via the app
+         * User can stop playback via MPD with pause button
+         */
     }
 
     public static void Play(final String url, final Context context) {
@@ -143,9 +144,21 @@ public class MPDClient {
                 Log.d(TAG, "Check connection...");
             }
             Socket s = new Socket();
-            // Timeout for local addresses should be as low as possible. Or you'll be waiting many seconds for a couple of servers if one (or more) of them will be unreachable
-            int timeout = mpd_hostname.startsWith("192.168.") || mpd_hostname.startsWith("127.0.") || mpd_hostname.startsWith("localhost") || mpd_hostname.startsWith("10.") || mpd_hostname.contains(".local") ? 500 : 3 * 1000;
-            // If you'll create the socket with default constructor new Socket(hostname, port) you will get 3 min timeout if the server is unreachable
+            /*
+             * Timeout for local addresses should be as low as possible.
+             * Or you'll be waiting many seconds for a couple of servers if one (or more) of them will be unreachable
+             */
+            int timeout = mpd_hostname.startsWith("192.168.")
+                    || mpd_hostname.startsWith("127.0.")
+                    || mpd_hostname.startsWith("localhost")
+                    || mpd_hostname.startsWith("10.")
+                    || mpd_hostname.contains(".local") ? 1000
+                    : 3 * 1000;
+            /*
+             * If you'll create the socket with default constructor:
+             * new Socket(hostname, port)
+             * you will get 3 min timeout if the server is unreachable
+             */
             s.connect(new InetSocketAddress(mpd_hostname, mpd_port), timeout);
             BufferedReader reader = new BufferedReader(new InputStreamReader(s.getInputStream()));
             BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(s.getOutputStream()));

--- a/app/src/main/java/net/programmierecke/radiodroid2/adapters/ItemAdapterStation.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/adapters/ItemAdapterStation.java
@@ -279,12 +279,16 @@ public class ItemAdapterStation
 
         holder.starredStatusIcon.setVisibility(favouriteManager.has(station.ID) ? View.VISIBLE : View.GONE);
 
-        if (station.ClickTrend < 0)
-            holder.imageTrend.setImageResource(R.drawable.ic_trending_down_black_24dp);
-        else if (station.ClickTrend > 0)
-            holder.imageTrend.setImageResource(R.drawable.ic_trending_up_black_24dp);
-        else
-            holder.imageTrend.setImageResource(R.drawable.ic_trending_flat_black_24dp);
+        if (prefs.getBoolean("click_trend_icon_visible", true)) {
+            if (station.ClickTrend < 0)
+                holder.imageTrend.setImageResource(R.drawable.ic_trending_down_black_24dp);
+            else if (station.ClickTrend > 0)
+                holder.imageTrend.setImageResource(R.drawable.ic_trending_up_black_24dp);
+            else
+                holder.imageTrend.setImageResource(R.drawable.ic_trending_flat_black_24dp);
+        } else {
+            holder.imageTrend.setVisibility(View.GONE);
+        }
 
         Drawable flag = CountryFlagsLoader.getInstance().getFlag(activity, station.Country);
 

--- a/app/src/main/java/net/programmierecke/radiodroid2/data/DataRadioStation.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/data/DataRadioStation.java
@@ -77,7 +77,9 @@ public class DataRadioStation {
 							aStation.IconUrl = anObject.getString("favicon");
 							aStation.Language = anObject.getString("language");
 							aStation.ClickCount = anObject.getInt("clickcount");
-							aStation.ClickTrend = anObject.getInt("clicktrend");
+							if (anObject.has("clicktrend")) {
+								aStation.ClickTrend = anObject.getInt("clicktrend");
+							}
 							if (anObject.has("bitrate")) {
 								aStation.Bitrate = anObject.getInt("bitrate");
 							}
@@ -123,7 +125,9 @@ public class DataRadioStation {
 					aStation.IconUrl = anObject.getString("favicon");
 					aStation.Language = anObject.getString("language");
 					aStation.ClickCount = anObject.getInt("clickcount");
-					aStation.ClickTrend = anObject.getInt("clicktrend");
+					if (anObject.has("clicktrend")) {
+						aStation.ClickTrend = anObject.getInt("clicktrend");
+					}
 					if (anObject.has(("bitrate"))) {
 						aStation.Bitrate = anObject.getInt("bitrate");
 					}

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -81,6 +81,10 @@
     <string name="settings_icon_click_toggles_favorite_on">Нажатие на иконку станции добавит или удалит её из избранного</string>
     <string name="settings_icon_click_toggles_favorite_off">Нажатие на иконку начнёт проигрывание</string>
 
+    <string name="settings_click_trend_icon_visible">Иконка тренда</string>
+    <string name="settings_click_trend_icon_visible_on">Иконка тренда будет видна на каждой станции</string>
+    <string name="settings_click_trend_icon_visible_off">Иконка тренда будет скрыта</string>
+
     <string name="settings_alarm">Будильник</string>
     <string name="settings_alarm_external">Запускать в приложении</string>
     <string name="settings_alarm_external_desc">Запускать будильник, используя другое приложение</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,6 +87,10 @@
     <string name="settings_icon_click_toggles_favorite_on">Clicking station icon adds or removes this as favorite</string>
     <string name="settings_icon_click_toggles_favorite_off">Clicking station icon starts playing</string>
 
+    <string name="settings_click_trend_icon_visible">Click trend icon</string>
+    <string name="settings_click_trend_icon_visible_on">Icon will be visible</string>
+    <string name="settings_click_trend_icon_visible_off">Icon will be hidden</string>
+
     <string name="settings_alarm">Alarm</string>
     <string name="settings_alarm_external">Open external</string>
     <string name="settings_alarm_external_desc">Open the alarm with default external app</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -68,6 +68,13 @@
             android:title="@string/settings_show_broken" />
 
         <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="click_trend_icon_visible"
+            android:summaryOff="@string/settings_click_trend_icon_visible_off"
+            android:summaryOn="@string/settings_click_trend_icon_visible_on"
+            android:title="@string/settings_click_trend_icon_visible" />
+
+        <CheckBoxPreference
             android:defaultValue="false"
             android:key="single_use_tags"
             android:summaryOff="@string/settings_single_use_tags_desc_off"


### PR DESCRIPTION
- favorites and history were empty after one of the previous commits. Fixed
- NPE when switching between tabs. Fixed
- expanded comments in MDPClient and made timeout equals to 1 second
- made click trend icon hideable

closes #305 #317