### PR TITLE
A11y: Dynamic content descriptions

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentPlayer.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentPlayer.java
@@ -103,8 +103,10 @@ public class FragmentPlayer extends Fragment {
 				public void onClick(View v) {
 					if (PlayerServiceUtil.isPlaying() || MPDClient.isPlaying) {
 						buttonPause.setImageResource(R.drawable.ic_play_circle);
+						buttonPause.setContentDescription(getResources().getString(R.string.detail_play));
 						if (PlayerServiceUtil.isRecording()) {
 							buttonRecord.setImageResource(R.drawable.ic_start_recording);
+							buttonRecord.setContentDescription(getResources().getString(R.string.image_button_record));
 							String recordingInfo = getResources().getString(R.string.player_info_recorded_to, PlayerServiceUtil.getCurrentRecordFileName());
 							textViewRecordingInfo.setText(recordingInfo);
 							PlayerServiceUtil.stopRecording();
@@ -117,6 +119,7 @@ public class FragmentPlayer extends Fragment {
 							MPDClient.Stop(getContext());
 					} else {
 						buttonPause.setImageResource(R.drawable.ic_pause_circle);
+	buttonPause.setContentDescription(getResources().getString(R.string.detail_pause));
 						SetInfoFromHistory(true);
 					}
 				}
@@ -130,12 +133,14 @@ public class FragmentPlayer extends Fragment {
 				public void onClick(View v) {
 					if (PlayerServiceUtil.isRecording()) {
 						buttonRecord.setImageResource(R.drawable.ic_start_recording);
+						buttonRecord.setContentDescription(getResources().getString(R.string.image_button_record));
 						String recordingInfo = getResources().getString(R.string.player_info_recorded_to,PlayerServiceUtil.getCurrentRecordFileName());
 						textViewRecordingInfo.setText(recordingInfo);
 						PlayerServiceUtil.stopRecording();
 					} else if(PlayerServiceUtil.isPlaying()) {
 						if (Utils.verifyStoragePermissions(getActivity())) {
 							buttonRecord.setImageResource(R.drawable.ic_stop_recording);
+							buttonRecord.setContentDescription(getResources().getString(R.string.detail_stop));
 							PlayerServiceUtil.startRecording();
 							if (PlayerServiceUtil.getCurrentRecordFileName() != null && PlayerServiceUtil.isRecording()){
 								String recordingInfo = getResources().getString(R.string.player_info_recording_to,PlayerServiceUtil.getCurrentRecordFileName());
@@ -227,8 +232,10 @@ public class FragmentPlayer extends Fragment {
 		buttonPause = (ImageButton) getActivity().findViewById(R.id.buttonPause);
 		if (PlayerServiceUtil.isPlaying() || MPDClient.isPlaying) {
 			buttonPause.setImageResource(R.drawable.ic_pause_circle);
+			buttonPause.setContentDescription(getResources().getString(R.string.detail_pause));
 		} else {
 			buttonPause.setImageResource(R.drawable.ic_play_circle);
+			buttonPause.setContentDescription(getResources().getString(R.string.detail_play));
 		}
 
 		buttonRecord = (ImageButton) getActivity().findViewById(R.id.buttonRecord);
@@ -237,12 +244,15 @@ public class FragmentPlayer extends Fragment {
 
 		if (PlayerServiceUtil.isRecording()) {
 			buttonRecord.setImageResource(R.drawable.ic_stop_recording);
+			buttonRecord.setContentDescription(getResources().getString(R.string.detail_stop));
 			aTextViewName.setTextColor(getResources().getColor(R.color.startRecordingColor));
 		} else if (android.os.Environment.getExternalStorageDirectory().canWrite()) {
 			buttonRecord.setImageResource(R.drawable.ic_start_recording);
+			buttonRecord.setContentDescription(getResources().getString(R.string.image_button_record));
 			aTextViewName.setTextColor(tv.data);
 		} else {
 			buttonRecord.setImageResource(R.drawable.ic_fiber_manual_record_black_50dp);
+			buttonRecord.setContentDescription(getResources().getString(R.string.image_button_record_request_permission));
 			aTextViewName.setTextColor(tv.data);
 		}
 
@@ -314,8 +324,10 @@ public class FragmentPlayer extends Fragment {
 				if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
 					PlayerServiceUtil.startRecording();
 					buttonRecord.setImageResource(R.drawable.ic_fiber_manual_record_red_50dp);
+					buttonRecord.setContentDescription(getResources().getString(R.string.detail_stop));
 				} else {
 					buttonRecord.setImageResource(R.drawable.ic_fiber_manual_record_black_50dp);
+			buttonRecord.setContentDescription(getResources().getString(R.string.image_button_record_request_permission));
 					Toast toast = Toast.makeText(getActivity(), getResources().getString(R.string.error_record_needs_write), Toast.LENGTH_SHORT);
 					toast.show();
 				}

--- a/app/src/main/java/net/programmierecke/radiodroid2/adapters/ItemAdapterRadioAlarm.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/adapters/ItemAdapterRadioAlarm.java
@@ -85,6 +85,7 @@ public class ItemAdapterRadioAlarm extends ArrayAdapter<DataRadioStationAlarm> {
 			});
 		}
 		repeatDaysView.setVisibility(aData.repeating ? View.VISIBLE : View.GONE);
+		buttonRepeating.setContentDescription(this.context.getResources().getString(aData.repeating ? R.string.image_button_dont_repeat : R.string.image_button_repeat));
 		return v;
 	}
 

--- a/app/src/main/java/net/programmierecke/radiodroid2/adapters/ItemAdapterStation.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/adapters/ItemAdapterStation.java
@@ -217,6 +217,8 @@ public class ItemAdapterStation
 
             if (prefs.getBoolean("icon_click_toggles_favorite", true)) {
 
+                final boolean isInFavorites = favouriteManager.has(station.ID);
+                holder.imageViewIcon.setContentDescription(getContext().getApplicationContext().getString(isInFavorites ? R.string.detail_unstar : R.string.detail_star));
                 holder.imageViewIcon.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View view) {
@@ -243,6 +245,7 @@ public class ItemAdapterStation
         holder.textViewTags.setVisibility(isExpanded ? View.GONE : View.VISIBLE);
 
         holder.buttonMore.setImageResource(isExpanded ? R.drawable.ic_expand_less_black_24dp : R.drawable.ic_expand_more_black_24dp);
+        holder.buttonMore.setContentDescription(getContext().getApplicationContext().getString(isExpanded ? R.string.image_button_less : R.string.image_button_more));
         holder.buttonMore.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -329,6 +332,7 @@ public class ItemAdapterStation
 
             if (favouriteManager.has(station.ID)) {
                 holder.buttonBookmark.setImageResource(R.drawable.ic_star_black_24dp);
+                holder.buttonBookmark.setContentDescription(getContext().getApplicationContext().getString(R.string.detail_unstar));
                 holder.buttonBookmark.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View view) {
@@ -342,6 +346,7 @@ public class ItemAdapterStation
                 });
             } else {
                 holder.buttonBookmark.setImageResource(R.drawable.ic_star_border_black_24dp);
+                holder.buttonBookmark.setContentDescription(getContext().getApplicationContext().getString(R.string.detail_star));
                 holder.buttonBookmark.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View view) {

--- a/app/src/main/res/layout/layout_player_status.xml
+++ b/app/src/main/res/layout/layout_player_status.xml
@@ -46,6 +46,7 @@
                 android:layout_marginRight="8dp"
                 android:layout_marginEnd="8dp"
                 android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/image_button_recordings"
                 app:srcCompat="@drawable/ic_list_24dp"
                 android:tint="?attr/colorAccent"
                 android:layout_toLeftOf="@+id/buttonRecord"/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -183,6 +183,8 @@
     <string name="image_button_recordings">Recordings</string>
     <string name="image_button_delete">Delete</string>
     <string name="image_button_more">More</string>
+    <string name="image_button_repeat">Repeat</string>
+    <string name="image_button_dont_repeat">Do not repeat</string>
 
     <string name="media_route_menu_title">GoogleCast</string>
     <string name="app_id">5A97BAE4</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -184,6 +184,7 @@
     <string name="image_button_recordings">Recordings</string>
     <string name="image_button_delete">Delete</string>
     <string name="image_button_more">More</string>
+    <string name="image_button_less">Less</string>
     <string name="image_button_repeat">Repeat</string>
     <string name="image_button_dont_repeat">Do not repeat</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -180,6 +180,7 @@
 
     <string name="image_button_disable">Disable</string>
     <string name="image_button_record">Record</string>
+    <string name="image_button_record_request_permission">Request permissions and record</string>
     <string name="image_button_recordings">Recordings</string>
     <string name="image_button_delete">Delete</string>
     <string name="image_button_more">More</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -180,6 +180,7 @@
 
     <string name="image_button_disable">Disable</string>
     <string name="image_button_record">Record</string>
+    <string name="image_button_recordings">Recordings</string>
     <string name="image_button_delete">Delete</string>
     <string name="image_button_more">More</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -180,7 +180,7 @@
 
     <string name="image_button_disable">Disable</string>
     <string name="image_button_record">Record</string>
-    <string name="image_button_record_request_permission">Request permissions and record</string>
+    <string name="image_button_record_request_permission">Request permissions for recording</string>
     <string name="image_button_recordings">Recordings</string>
     <string name="image_button_delete">Delete</string>
     <string name="image_button_more">More</string>


### PR DESCRIPTION
Since I have last looked at the accessibility shortcomings of the app, many things got redesigned. Part of the redesign are some buttons which became multi purpose e.g. recording button is working as Record and Stop recording button, Play / Pause, Star / Unstar and similar. I have added one missing contentDescription and dynamically set contentDescription in code at all the places where the imageResource is changed.
I think this all is usefull to screen reader users.
I've tested all these changes on Nokia 6 running Android 8.1.0 and Samsung Galaxy S 7 running Android 7.0.