### PR TITLE
A11y: Add content description for the click trend icon

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/adapters/ItemAdapterStation.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/adapters/ItemAdapterStation.java
@@ -283,12 +283,16 @@ public class ItemAdapterStation
         holder.starredStatusIcon.setVisibility(favouriteManager.has(station.ID) ? View.VISIBLE : View.GONE);
 
         if (prefs.getBoolean("click_trend_icon_visible", true)) {
-            if (station.ClickTrend < 0)
+            if (station.ClickTrend < 0) {
                 holder.imageTrend.setImageResource(R.drawable.ic_trending_down_black_24dp);
-            else if (station.ClickTrend > 0)
+                holder.imageTrend.setContentDescription(getContext().getApplicationContext().getString(R.string.icon_click_trend_decreasing));
+            } else if (station.ClickTrend > 0) {
                 holder.imageTrend.setImageResource(R.drawable.ic_trending_up_black_24dp);
-            else
+                holder.imageTrend.setContentDescription(getContext().getApplicationContext().getString(R.string.icon_click_trend_increasing));
+            } else {
                 holder.imageTrend.setImageResource(R.drawable.ic_trending_flat_black_24dp);
+                holder.imageTrend.setContentDescription(getContext().getApplicationContext().getString(R.string.icon_click_trend_stable));
+            }
         } else {
             holder.imageTrend.setVisibility(View.GONE);
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -187,6 +187,9 @@
     <string name="image_button_less">Less</string>
     <string name="image_button_repeat">Repeat</string>
     <string name="image_button_dont_repeat">Do not repeat</string>
+    <string name="icon_click_trend_decreasing">Popularity decreasing</string>
+    <string name="icon_click_trend_increasing">Popularity increasing</string>
+    <string name="icon_click_trend_stable">Popularity stable</string>
 
     <string name="media_route_menu_title">GoogleCast</string>
     <string name="app_id">5A97BAE4</string>


### PR DESCRIPTION
Add content description for the click trend icon in the list of stations. Disabling the icon from showing also causes assistive tools
not to report this content description.
It would be awesome to get the strings refined by the native english speaker I think but functionally it's working great.
Hopefully now all the usefull buttons and icons are exposed to screen reader users.