### PR TITLE
 Add support for proxies

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/ActivityRadioStationDetail.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/ActivityRadioStationDetail.java
@@ -20,6 +20,8 @@ import android.widget.TimePicker;
 
 import net.programmierecke.radiodroid2.data.DataRadioStation;
 
+import okhttp3.OkHttpClient;
+
 public class ActivityRadioStationDetail extends AppCompatActivity implements TimePickerDialog.OnTimeSetListener {
 	private DataRadioStation itsStation;
 	private MenuItem m_Menu_Star;
@@ -48,10 +50,13 @@ public class ActivityRadioStationDetail extends AppCompatActivity implements Tim
 		UpdateMenu();
 
 		getApplicationContext().sendBroadcast(new Intent(ActivityMain.ACTION_SHOW_LOADING));
+
+		final OkHttpClient httpClient = radioDroidApp.getHttpClient();
+
 		new AsyncTask<Void, Void, String>() {
 			@Override
 			protected String doInBackground(Void... params) {
-				return Utils.downloadFeed(getApplicationContext(), RadioBrowserServerManager.getWebserviceEndpoint(getApplicationContext(), String.format(Locale.US, "json/stations/byid/%s", aStationID)),true,null);
+				return Utils.downloadFeed(httpClient, getApplicationContext(), RadioBrowserServerManager.getWebserviceEndpoint(getApplicationContext(), String.format(Locale.US, "json/stations/byid/%s", aStationID)),true,null);
 			}
 
 			@Override
@@ -100,13 +105,17 @@ public class ActivityRadioStationDetail extends AppCompatActivity implements Tim
 	@Override
 	public boolean onOptionsItemSelected(MenuItem item) {
 		switch (item.getItemId()) {
-			case R.id.action_play:
-				Utils.Play(itsStation,this,false);
+			case R.id.action_play: {
+				RadioDroidApp radioDroidApp = (RadioDroidApp) getApplication();
+				Utils.Play(radioDroidApp.getHttpClient(), itsStation, this, false);
 				return true;
+			}
 
-			case R.id.action_share:
-				Utils.Play(itsStation,this,true);
+			case R.id.action_share: {
+				RadioDroidApp radioDroidApp = (RadioDroidApp) getApplication();
+				Utils.Play(radioDroidApp.getHttpClient(), itsStation, this, true);
 				return true;
+			}
 
 			case R.id.action_star:
 				Star();

--- a/app/src/main/java/net/programmierecke/radiodroid2/AlarmReceiver.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/AlarmReceiver.java
@@ -19,6 +19,8 @@ import android.widget.Toast;
 
 import net.programmierecke.radiodroid2.data.DataRadioStation;
 
+import okhttp3.OkHttpClient;
+
 public class AlarmReceiver extends BroadcastReceiver {
     String url;
     int alarmId;
@@ -118,12 +120,15 @@ public class AlarmReceiver extends BroadcastReceiver {
     int timeout = 10;
 
     private void Play(final Context context, final String stationId) {
+        RadioDroidApp radioDroidApp = (RadioDroidApp) context.getApplicationContext();
+        final OkHttpClient httpClient = radioDroidApp.getHttpClient();
+
         new AsyncTask<Void, Void, String>() {
             @Override
             protected String doInBackground(Void... params) {
                 String result = null;
                 for (int i=0;i<20;i++){
-                    result = Utils.getRealStationLink(context, stationId);
+                    result = Utils.getRealStationLink(httpClient, context, stationId);
                     if (result != null){
                         return result;
                     }

--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentBase.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentBase.java
@@ -13,6 +13,8 @@ import android.widget.Toast;
 
 import java.util.HashMap;
 
+import okhttp3.OkHttpClient;
+
 public class FragmentBase extends Fragment {
     private static final String TAG = "FragmentBase";
 
@@ -77,6 +79,10 @@ public class FragmentBase extends Fragment {
                 if (getContext() != null && displayProgress) {
                     getContext().sendBroadcast(new Intent(ActivityMain.ACTION_SHOW_LOADING));
                 }
+
+                RadioDroidApp radioDroidApp = (RadioDroidApp) getActivity().getApplication();
+                final OkHttpClient httpClient = radioDroidApp.getHttpClient();
+
                 new AsyncTask<Void, Void, String>() {
                     @Override
                     protected String doInBackground(Void... params) {
@@ -84,7 +90,7 @@ public class FragmentBase extends Fragment {
                         if (!show_broken) {
                             p.put("hidebroken", "true");
                         }
-                        return Utils.downloadFeed(getActivity(), url, forceUpdate, p);
+                        return Utils.downloadFeed(httpClient, getActivity(), url, forceUpdate, p);
                     }
 
                     @Override

--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentHistory.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentHistory.java
@@ -30,7 +30,8 @@ public class FragmentHistory extends Fragment {
     void onStationClick(DataRadioStation theStation) {
         Context context = getContext();
 
-        Utils.Play(theStation, context);
+        RadioDroidApp radioDroidApp = (RadioDroidApp) getActivity().getApplication();
+        Utils.Play(radioDroidApp.getHttpClient(), theStation, context);
 
         historyManager.add(theStation);
 

--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentPlayer.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentPlayer.java
@@ -192,9 +192,9 @@ public class FragmentPlayer extends Fragment {
 
         if(history.length > 0) {
             DataRadioStation lastStation = history[0];
-            if(startPlaying)
-                Utils.Play(lastStation, getContext());
-            else {
+            if(startPlaying) {
+				Utils.Play(radioDroidApp.getHttpClient(),lastStation, getContext());
+			} else {
                 aTextViewName.setText(lastStation.Name);
 
                 if (!Utils.shouldLoadIcons(getContext()))

--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentServerInfo.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentServerInfo.java
@@ -16,6 +16,8 @@ import net.programmierecke.radiodroid2.adapters.ItemAdapterStatistics;
 import net.programmierecke.radiodroid2.data.DataStatistics;
 import net.programmierecke.radiodroid2.interfaces.IFragmentRefreshable;
 
+import okhttp3.OkHttpClient;
+
 public class FragmentServerInfo extends Fragment implements IFragmentRefreshable {
     private ItemAdapterStatistics itemAdapterStatistics;
 
@@ -38,12 +40,16 @@ public class FragmentServerInfo extends Fragment implements IFragmentRefreshable
 
     void Download(final boolean forceUpdate){
         getContext().sendBroadcast(new Intent(ActivityMain.ACTION_SHOW_LOADING));
+
+        RadioDroidApp radioDroidApp = (RadioDroidApp) getActivity().getApplication();
+        final OkHttpClient httpClient = radioDroidApp.getHttpClient();
+
         new AsyncTask<Void, Void, String>() {
             @Override
             protected String doInBackground(Void... params) {
                 String endpoint = RadioBrowserServerManager.getWebserviceEndpoint(getActivity(),"json/stats");
                 if (endpoint != null) {
-                    return Utils.downloadFeed(getActivity(), endpoint, forceUpdate, null);
+                    return Utils.downloadFeed(httpClient, getActivity(), endpoint, forceUpdate, null);
                 }
                 return null;
             }

--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentSettings.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentSettings.java
@@ -24,6 +24,7 @@ import android.widget.Toast;
 
 import net.programmierecke.radiodroid2.data.MPDServer;
 import net.programmierecke.radiodroid2.interfaces.IApplicationSelected;
+import net.programmierecke.radiodroid2.proxy.ProxySettingsDialog;
 
 import java.lang.ref.WeakReference;
 import java.net.InetAddress;
@@ -66,6 +67,17 @@ public class FragmentSettings extends PreferenceFragmentCompat implements Shared
                 return false;
             }
         });
+
+        findPreference("settings_proxy").setOnPreferenceClickListener(new OnPreferenceClickListener() {
+            @Override
+            public boolean onPreferenceClick(Preference preference) {
+                ProxySettingsDialog proxySettingsDialog = new ProxySettingsDialog();
+                proxySettingsDialog.setCancelable(true);
+                proxySettingsDialog.show(getFragmentManager(), "");
+                return false;
+            }
+        });
+
         findPreference("mpd_servers_viewer").setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
             @Override
             public boolean onPreferenceClick(Preference preference) {

--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentStarred.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentStarred.java
@@ -26,7 +26,9 @@ public class FragmentStarred extends Fragment implements IAdapterRefreshable, IC
     private HistoryManager historyManager;
 
     void onStationClick(DataRadioStation theStation) {
-        Utils.Play(theStation, getContext());
+        RadioDroidApp radioDroidApp = (RadioDroidApp) getActivity().getApplication();
+
+        Utils.Play(radioDroidApp.getHttpClient(), theStation, getContext());
 
         historyManager.add(theStation);
     }

--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentStations.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentStations.java
@@ -31,7 +31,9 @@ public class FragmentStations extends FragmentBase {
 
     void onStationClick(DataRadioStation theStation) {
         Context context = getContext();
-        Utils.Play(theStation, context);
+
+        RadioDroidApp radioDroidApp = (RadioDroidApp) getActivity().getApplication();
+        Utils.Play(radioDroidApp.getHttpClient(), theStation, context);
 
         historyManager.add(theStation);
 

--- a/app/src/main/java/net/programmierecke/radiodroid2/RadioDroidApp.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/RadioDroidApp.java
@@ -1,12 +1,25 @@
 package net.programmierecke.radiodroid2;
 
 import android.app.Application;
+import android.content.SharedPreferences;
+import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatDelegate;
+import android.support.v7.preference.PreferenceManager;
 
 import com.jakewharton.picasso.OkHttp3Downloader;
 import com.squareup.picasso.Picasso;
 
+import net.programmierecke.radiodroid2.proxy.ProxySettings;
 import net.programmierecke.radiodroid2.recording.RecordingsManager;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import okhttp3.ConnectionPool;
+import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
 
 public class RadioDroidApp extends Application {
 
@@ -14,11 +27,36 @@ public class RadioDroidApp extends Application {
     private FavouriteManager favouriteManager;
     private RecordingsManager recordingsManager;
 
+    private ConnectionPool connectionPool;
+    private OkHttpClient httpClient;
+
+    public class UserAgentInterceptor implements Interceptor {
+
+        private final String userAgent;
+
+        public UserAgentInterceptor(String userAgent) {
+            this.userAgent = userAgent;
+        }
+
+        @Override
+        public Response intercept(Chain chain) throws IOException {
+            Request originalRequest = chain.request();
+            Request requestWithUserAgent = originalRequest.newBuilder()
+                    .header("User-Agent", userAgent)
+                    .build();
+            return chain.proceed(requestWithUserAgent);
+        }
+    }
+
     @Override
     public void onCreate() {
         super.onCreate();
 
         AppCompatDelegate.setCompatVectorFromResourcesEnabled(true);
+
+        connectionPool = new ConnectionPool();
+
+        rebuildHttpClient();
 
         Picasso.Builder builder = new Picasso.Builder(this);
         builder.downloader(new OkHttp3Downloader(this, Integer.MAX_VALUE));
@@ -33,6 +71,15 @@ public class RadioDroidApp extends Application {
         recordingsManager = new RecordingsManager();
     }
 
+    public void rebuildHttpClient() {
+        httpClient = newHttpClient()
+                .connectTimeout(10, TimeUnit.SECONDS)
+                .writeTimeout(10, TimeUnit.SECONDS)
+                .readTimeout(10, TimeUnit.SECONDS)
+                .addInterceptor(new UserAgentInterceptor("RadioDroid2/" + BuildConfig.VERSION_NAME))
+                .build();
+    }
+
     public HistoryManager getHistoryManager() {
         return historyManager;
     }
@@ -43,5 +90,23 @@ public class RadioDroidApp extends Application {
 
     public RecordingsManager getRecordingsManager() {
         return recordingsManager;
+    }
+
+    public OkHttpClient getHttpClient() {
+        return httpClient;
+    }
+
+    public OkHttpClient.Builder newHttpClient() {
+        OkHttpClient.Builder builder = new OkHttpClient.Builder().connectionPool(connectionPool);
+        setCurrentOkHttpProxy(builder);
+        return builder;
+    }
+
+    public void setCurrentOkHttpProxy(@NonNull OkHttpClient.Builder builder) {
+        SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(this);
+        ProxySettings proxySettings = ProxySettings.fromPreferences(sharedPref);
+        if (proxySettings != null) {
+            Utils.setOkHttpProxy(builder, proxySettings);
+        }
     }
 }

--- a/app/src/main/java/net/programmierecke/radiodroid2/StationSaveManager.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/StationSaveManager.java
@@ -29,6 +29,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Vector;
 
+import okhttp3.OkHttpClient;
+
 public class StationSaveManager {
     Context context;
     List<DataRadioStation> listStations = new ArrayList<DataRadioStation>();
@@ -206,6 +208,9 @@ public class StationSaveManager {
     protected final String M3U_PREFIX = "#RADIOBROWSERUUID:";
 
     boolean SaveM3UInternal(String filePath, String fileName){
+        final RadioDroidApp radioDroidApp = (RadioDroidApp) context.getApplicationContext();
+        final OkHttpClient httpClient = radioDroidApp.getHttpClient();
+
         try {
             File f = new File(filePath, fileName);
             BufferedWriter bw = new BufferedWriter(new FileWriter(f, false));
@@ -213,7 +218,7 @@ public class StationSaveManager {
             for (DataRadioStation station : listStations) {
                 String result = null;
                 for (int i=0;i<20;i++){
-                    result = Utils.getRealStationLink(context, station.ID);
+                    result = Utils.getRealStationLink(httpClient, context, station.ID);
                     if (result != null){
                         break;
                     }
@@ -256,11 +261,14 @@ public class StationSaveManager {
             BufferedReader br = new BufferedReader(new FileReader(f));
             String line;
 
+            final RadioDroidApp radioDroidApp = (RadioDroidApp) context.getApplicationContext();
+            final OkHttpClient httpClient = radioDroidApp.getHttpClient();
+
             while ((line = br.readLine()) != null) {
                 if (line.startsWith(M3U_PREFIX)){
                     try {
                         String uuid = line.substring(M3U_PREFIX.length()).trim();
-                        DataRadioStation station = Utils.getStationByUuid(context, uuid);
+                        DataRadioStation station = Utils.getStationByUuid(httpClient, context, uuid);
                         if (station != null) {
                             loadedItems.add(station);
                         }

--- a/app/src/main/java/net/programmierecke/radiodroid2/adapters/ItemAdapterStation.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/adapters/ItemAdapterStation.java
@@ -39,6 +39,8 @@ import net.programmierecke.radiodroid2.utils.RecyclerItemSwipeHelper;
 import net.programmierecke.radiodroid2.utils.SwipeableViewHolder;
 import net.programmierecke.radiodroid2.views.TagsView;
 
+import okhttp3.OkHttpClient;
+
 public class ItemAdapterStation
         extends RecyclerView.Adapter<ItemAdapterStation.StationViewHolder>
         implements TimePickerDialog.OnTimeSetListener, RecyclerItemSwipeHelper.SwipeCallback<ItemAdapterStation.StationViewHolder> {
@@ -438,10 +440,14 @@ public class ItemAdapterStation
 
     private void retrieveAndCopyStreamUrlToClipboard(final DataRadioStation station) {
         getContext().sendBroadcast(new Intent(ActivityMain.ACTION_SHOW_LOADING));
+
+        final RadioDroidApp radioDroidApp = (RadioDroidApp) getContext().getApplicationContext();
+        final OkHttpClient httpClient = radioDroidApp.getHttpClient();
+
         new AsyncTask<Void, Void, String>() {
             @Override
             protected String doInBackground(Void... params) {
-                return Utils.getRealStationLink(getContext().getApplicationContext(), station.ID);
+                return Utils.getRealStationLink(httpClient, radioDroidApp, station.ID);
             }
 
             @Override
@@ -475,10 +481,13 @@ public class ItemAdapterStation
     }
 
     private void vote(final String stationID) {
+        final RadioDroidApp radioDroidApp = (RadioDroidApp) getContext().getApplicationContext();
+        final OkHttpClient httpClient = radioDroidApp.getHttpClient();
+
         new AsyncTask<Void, Void, String>() {
             @Override
             protected String doInBackground(Void... params) {
-                return Utils.downloadFeed(activity, RadioBrowserServerManager.getWebserviceEndpoint(activity,"json/vote/" + stationID), true, null);
+                return Utils.downloadFeed(httpClient, activity, RadioBrowserServerManager.getWebserviceEndpoint(activity,"json/vote/" + stationID), true, null);
             }
 
             @Override
@@ -517,10 +526,14 @@ public class ItemAdapterStation
 
     private void share(final DataRadioStation station) {
         getContext().sendBroadcast(new Intent(ActivityMain.ACTION_SHOW_LOADING));
+
+        final RadioDroidApp radioDroidApp = (RadioDroidApp) getContext().getApplicationContext();
+        final OkHttpClient httpClient = radioDroidApp.getHttpClient();
+
         new AsyncTask<Void, Void, String>() {
             @Override
             protected String doInBackground(Void... params) {
-                return Utils.getRealStationLink(getContext().getApplicationContext(), station.ID);
+                return Utils.getRealStationLink(httpClient, radioDroidApp, station.ID);
             }
 
             @Override

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/RadioPlayer.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/RadioPlayer.java
@@ -13,6 +13,7 @@ import android.util.Log;
 
 import net.programmierecke.radiodroid2.BuildConfig;
 import net.programmierecke.radiodroid2.HttpClient;
+import net.programmierecke.radiodroid2.RadioDroidApp;
 import net.programmierecke.radiodroid2.Utils;
 import net.programmierecke.radiodroid2.data.ShoutcastInfo;
 import net.programmierecke.radiodroid2.data.StreamLiveInfo;
@@ -52,7 +53,6 @@ public class RadioPlayer implements PlayerWrapper.PlayListener, Recordable {
     }
 
     private PlayerWrapper player;
-    private OkHttpClient httpClient;
     private Context mainContext;
 
     private String streamName;
@@ -89,10 +89,6 @@ public class RadioPlayer implements PlayerWrapper.PlayListener, Recordable {
 
         playerThreadHandler = new Handler(playerThread.getLooper());
 
-        httpClient = HttpClient.getInstance().newBuilder()
-                .retryOnConnectionFailure(true)
-                .build();
-
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
             player = new ExoPlayerWrapper();
         } else {
@@ -113,7 +109,9 @@ public class RadioPlayer implements PlayerWrapper.PlayListener, Recordable {
         final int connectTimeout = prefs.getInt("stream_connect_timeout", 4);
         final int readTimeout = prefs.getInt("stream_read_timeout", 10);
 
-        final OkHttpClient customizedHttpClient = httpClient.newBuilder()
+        RadioDroidApp radioDroidApp = (RadioDroidApp) mainContext.getApplicationContext();
+
+        final OkHttpClient customizedHttpClient = radioDroidApp.newHttpClient()
                 .connectTimeout(connectTimeout, TimeUnit.SECONDS)
                 .readTimeout(readTimeout, TimeUnit.SECONDS)
                 .build();

--- a/app/src/main/java/net/programmierecke/radiodroid2/proxy/ProxySettings.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/proxy/ProxySettings.java
@@ -1,0 +1,30 @@
+package net.programmierecke.radiodroid2.proxy;
+
+import android.content.SharedPreferences;
+
+import com.google.gson.Gson;
+
+import java.net.Proxy;
+
+public class ProxySettings {
+    private final static String PREFERENCES_KEY = "proxySettings";
+
+    public String host;
+    public int port;
+    public String login;
+    public String password;
+    public Proxy.Type type;
+
+    public static ProxySettings fromPreferences(SharedPreferences sharedPref) {
+        Gson gson = new Gson();
+        String jsonStr = sharedPref.getString(PREFERENCES_KEY, "");
+
+        return gson.fromJson(jsonStr, ProxySettings.class);
+    }
+
+    public void toPreferences(SharedPreferences.Editor sharedPrefEditor) {
+        Gson gson = new Gson();
+        String jsonStr = gson.toJson(this);
+        sharedPrefEditor.putString(PREFERENCES_KEY, jsonStr);
+    }
+}

--- a/app/src/main/java/net/programmierecke/radiodroid2/proxy/ProxySettingsDialog.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/proxy/ProxySettingsDialog.java
@@ -1,0 +1,223 @@
+package net.programmierecke.radiodroid2.proxy;
+
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.content.SharedPreferences;
+import android.os.AsyncTask;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+import android.support.v7.app.AlertDialog;
+import android.support.v7.preference.PreferenceManager;
+import android.support.v7.widget.AppCompatSpinner;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.TextView;
+
+import net.programmierecke.radiodroid2.R;
+import net.programmierecke.radiodroid2.RadioDroidApp;
+import net.programmierecke.radiodroid2.Utils;
+
+import java.io.IOException;
+import java.lang.ref.WeakReference;
+import java.net.Proxy;
+import java.util.concurrent.TimeUnit;
+
+import okhttp3.Call;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public class ProxySettingsDialog extends DialogFragment {
+
+    final static private String TEST_ADDRESS = "http://radio-browser.info";
+
+    private EditText editProxyHost;
+    private EditText editProxyPort;
+    private AppCompatSpinner spinnerProxyType;
+    private EditText editLogin;
+    private EditText editProxyPassword;
+    private TextView textProxyTestResult;
+
+    private ArrayAdapter<Proxy.Type> proxyTypeAdapter;
+
+    private AsyncTask<Void, Void, Void> proxyTestTask;
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        LayoutInflater inflater = getActivity().getLayoutInflater();
+
+        View layout = inflater.inflate(R.layout.dialog_proxy_settings, null);
+
+        editProxyHost = layout.findViewById(R.id.edit_proxy_host);
+        editProxyPort = layout.findViewById(R.id.edit_proxy_port);
+        spinnerProxyType = layout.findViewById(R.id.spinner_proxy_type);
+        editLogin = layout.findViewById(R.id.edit_proxy_login);
+        editProxyPassword = layout.findViewById(R.id.edit_proxy_password);
+        textProxyTestResult = layout.findViewById(R.id.text_test_proxy_result);
+
+        proxyTypeAdapter = new ArrayAdapter<>(getContext(), android.R.layout.simple_spinner_item,
+                new Proxy.Type[]{Proxy.Type.DIRECT, Proxy.Type.HTTP, Proxy.Type.SOCKS});
+
+        spinnerProxyType.setAdapter(proxyTypeAdapter);
+
+        {
+            SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(getContext());
+            ProxySettings proxySettings = ProxySettings.fromPreferences(sharedPref);
+
+            if (proxySettings != null) {
+                editProxyHost.setText(proxySettings.host);
+                editProxyPort.setText(Integer.toString(proxySettings.port));
+                editLogin.setText(proxySettings.login);
+                editProxyPassword.setText(proxySettings.password);
+                spinnerProxyType.setSelection(proxyTypeAdapter.getPosition(proxySettings.type));
+            }
+        }
+
+        final Dialog dialog = builder.setView(layout)
+                .setPositiveButton(R.string.action_ok, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int id) {
+                        SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(getContext());
+                        SharedPreferences.Editor editor = sharedPref.edit();
+
+                        ProxySettings proxySettings = createProxySettings();
+                        proxySettings.toPreferences(editor);
+                        editor.apply();
+
+                        RadioDroidApp radioDroidApp = (RadioDroidApp) getActivity().getApplication();
+                        radioDroidApp.rebuildHttpClient();
+                    }
+                })
+                .setNegativeButton(R.string.action_cancel, new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        ProxySettingsDialog.this.getDialog().cancel();
+                    }
+                })
+                .setNeutralButton(R.string.settings_proxy_action_test, null)
+                .create();
+
+        dialog.setOnShowListener(new DialogInterface.OnShowListener() {
+            @Override
+            public void onShow(DialogInterface dialogInterface) {
+                Button button = ((AlertDialog) dialog).getButton(AlertDialog.BUTTON_NEUTRAL);
+                button.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        ProxySettings proxySettings = createProxySettings();
+                        testProxy(proxySettings);
+                    }
+                });
+            }
+        });
+
+        return dialog;
+    }
+
+    @Override
+    public void onDismiss(DialogInterface dialog) {
+        super.onDismiss(dialog);
+
+        if (proxyTestTask != null) {
+            proxyTestTask.cancel(true);
+        }
+    }
+
+    private ProxySettings createProxySettings() {
+        ProxySettings settings = new ProxySettings();
+
+        settings.host = editProxyHost.getText().toString();
+        settings.port = Integer.parseInt(editProxyPort.getText().toString());
+        settings.login = editLogin.getText().toString();
+        settings.password = editProxyPassword.getText().toString();
+        settings.type = proxyTypeAdapter.getItem(spinnerProxyType.getSelectedItemPosition());
+
+        return settings;
+    }
+
+    private static class ConnectionTesterTask extends AsyncTask<Void, Void, Void> {
+        private WeakReference<TextView> textProxyTestResult;
+
+        private OkHttpClient okHttpClient;
+        private Call call;
+
+        private String connectionSuccessStr;
+        private String connectionFailedStr;
+
+        private boolean requestSucceeded = false;
+        private String errorStr;
+
+        private ConnectionTesterTask(@NonNull RadioDroidApp radioDroidApp, @NonNull TextView textProxyTestResult,
+                                     @NonNull ProxySettings proxySettings) {
+            this.textProxyTestResult = new WeakReference<>(textProxyTestResult);
+
+            textProxyTestResult.setText("");
+
+            connectionSuccessStr = radioDroidApp.getString(R.string.settings_proxy_working, TEST_ADDRESS);
+            connectionFailedStr = radioDroidApp.getString(R.string.settings_proxy_not_working);
+
+            OkHttpClient.Builder builder = radioDroidApp.newHttpClient()
+                    .connectTimeout(10, TimeUnit.SECONDS)
+                    .writeTimeout(10, TimeUnit.SECONDS)
+                    .readTimeout(10, TimeUnit.SECONDS);
+
+            Utils.setOkHttpProxy(builder, proxySettings);
+            okHttpClient = builder.build();
+        }
+
+        @Override
+        protected void onPreExecute() {
+            super.onPreExecute();
+
+            Request.Builder builder = new Request.Builder().url(TEST_ADDRESS);
+            call = okHttpClient.newCall(builder.build());
+        }
+
+        @Override
+        protected Void doInBackground(Void... voids) {
+            try {
+                Response response = call.execute();
+                requestSucceeded = response.isSuccessful();
+                if (!requestSucceeded) {
+                    errorStr = response.message();
+                }
+            } catch (IOException e) {
+                requestSucceeded = false;
+                errorStr = e.getMessage();
+            }
+
+            return null;
+        }
+
+        @Override
+        protected void onPostExecute(Void v) {
+            super.onPostExecute(v);
+
+            TextView textResult = textProxyTestResult.get();
+            if (textResult == null) {
+                return;
+            }
+
+            if (requestSucceeded) {
+                textResult.setText(connectionSuccessStr);
+            } else {
+                textResult.setText(String.format(connectionFailedStr, TEST_ADDRESS, errorStr));
+            }
+        }
+    }
+
+    private void testProxy(@NonNull ProxySettings proxySettings) {
+        if (proxyTestTask != null) {
+            proxyTestTask.cancel(true);
+        }
+
+        RadioDroidApp radioDroidApp = (RadioDroidApp) getActivity().getApplication();
+        proxyTestTask = new ConnectionTesterTask(radioDroidApp, textProxyTestResult, proxySettings);
+        proxyTestTask.execute();
+    }
+}

--- a/app/src/main/res/layout/dialog_proxy_settings.xml
+++ b/app/src/main/res/layout/dialog_proxy_settings.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <EditText
+            android:id="@+id/edit_proxy_host"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="2"
+            android:hint="@string/hostname"
+            android:inputType="textUri" />
+
+        <EditText
+            android:id="@+id/edit_proxy_port"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:hint="@string/port"
+            android:inputType="number" />
+    </LinearLayout>
+
+    <android.support.v7.widget.AppCompatSpinner
+        android:id="@+id/spinner_proxy_type"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <EditText
+        android:id="@+id/edit_proxy_login"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/settings_proxy_login"
+        android:inputType="number" />
+
+    <EditText
+        android:id="@+id/edit_proxy_password"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/settings_proxy_password"
+        android:inputType="textPassword" />
+
+    <TextView
+        android:id="@+id/text_test_proxy_result"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:lines="2" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/layout_server_alert.xml
+++ b/app/src/main/res/layout/layout_server_alert.xml
@@ -28,7 +28,7 @@
                 android:layout_margin="10dp"
                 android:maxLines="1"
                 android:inputType="text"
-                android:hint="@string/alert_select_mpd_server_hostname"
+                android:hint="@string/hostname"
                 android:layout_toLeftOf="@id/mpd_server_port"
                 android:layout_toStartOf="@id/mpd_server_port"/>
 
@@ -39,7 +39,7 @@
                 android:textSize="15sp"
                 android:layout_margin="10dp"
                 android:maxLines="1"
-                android:hint="@string/alert_select_mpd_server_port"
+                android:hint="@string/port"
                 android:text="6600"
                 android:layout_alignParentRight="true"
                 android:layout_alignParentEnd="true"/>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -157,8 +157,8 @@
 
     <string name="alert_select_mpd_server">Ποιον εξυπηρετητή;</string>
     <string name="alert_select_mpd_server_name">Όνομα του εξυπηρετητή</string>
-    <string name="alert_select_mpd_server_hostname">Όνομα του οικοδεσπότη</string>
-    <string name="alert_select_mpd_server_port">Θύρα</string>
+    <string name="hostname">Όνομα του οικοδεσπότη</string>
+    <string name="port">Θύρα</string>
 
     <string name="alert_select_mpd_server_add">Προσθήκη</string>
     <string name="alert_select_mpd_server_save">Αποθήκευση</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -136,8 +136,8 @@
 
 	<string name="alert_select_mpd_server">¿En qué servidor?</string>
     <string name="alert_select_mpd_server_name">Nombre del servidor</string>
-    <string name="alert_select_mpd_server_hostname">Nombre del host</string>
-    <string name="alert_select_mpd_server_port">Puerto</string>
+    <string name="hostname">Nombre del host</string>
+    <string name="port">Puerto</string>
 
     <string name="alert_select_mpd_server_add">Añadir</string>
     <string name="alert_select_mpd_server_save">Guardar</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -102,7 +102,7 @@
     <string name="settings_alarm_sleep_timer_desc">Lejátszás leállítása %1$s perc után</string>
     <string name="settings_play">Lejátszó</string>
     <string name="settings_play_external">Külső megnyitása</string>
-    <string name="settings_play_external_desc">Az államosokon történő kattintás külső appot nyit meg<string>
+    <string name="settings_play_external_desc">Az államosokon történő kattintás külső appot nyit meg</string>
     <string name="settings_equalizer">Hangszínszabályzó</string>
 
     <string name="settings_connectivity">Kapcsolódás</string>
@@ -173,7 +173,7 @@
     <string name="player_info_status_stopped">leállítva</string>
     <string name="player_info_status_playing">lejátszás</string>
     <string name="player_info_status_recording">rögzítés</string>
-    <string name="player_info_status_playing_and_recording">lejátszás és rögzítés<string>
+    <string name="player_info_status_playing_and_recording">lejátszás és rögzítés</string>
     <string name="player_info_transferred">Átküldött adatok: %1$s</string>
     <string name="player_info_recording_to">Rögzítés ide:\n%1$s</string>
     <string name="player_info_recorded_to">Legutóbbi rögzítés:\n%1$s</string>
@@ -190,7 +190,7 @@
     <string name="image_button_less">Kevesebb</string>
     <string name="image_button_repeat">Ismétlés</string>
     <string name="image_button_dont_repeat">Ne legyen ismétlés</string>
-    <string name="icon_click_trend_decreasing">Csökkenő népszerűség<string>
+    <string name="icon_click_trend_decreasing">Csökkenő népszerűség</string>
     <string name="icon_click_trend_increasing">Növekvő népszerűség</string>
     <string name="icon_click_trend_stable">Stabil népszerűség</string>
 
@@ -198,7 +198,7 @@
     <string name="app_id">5A97BAE4</string>
 
     <string name="settings_mpd">Zenelejátszó démon</string>
-    <string name="settings_view_mpd_servers">Saját kiszolgálók<string>
+    <string name="settings_view_mpd_servers">Saját kiszolgálók</string>
     <string name="action_mpd_nok">MPD nincs csatlakoztatva</string>
     <string name="action_mpd_ok">MPD csatlakoztatva</string>
     <string name="action_mpd_connected">Kapcsolódva a kiszolgálóhoz: %1$s</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -135,8 +135,8 @@
 
     <string name="alert_select_mpd_server">Выберите сервер</string>
     <string name="alert_select_mpd_server_name">Имя сервера</string>
-    <string name="alert_select_mpd_server_hostname">Имя хоста</string>
-    <string name="alert_select_mpd_server_port">Порт</string>
+    <string name="hostname">Имя хоста</string>
+    <string name="port">Порт</string>
 
     <string name="alert_select_mpd_server_add">Добавить</string>
     <string name="alert_select_mpd_server_save">Сохранить</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -155,8 +155,8 @@
 
     <string name="alert_select_mpd_server">Ktorý server?</string>
     <string name="alert_select_mpd_server_name">Názouv servera</string>
-    <string name="alert_select_mpd_server_hostname">Názov hostiteľa</string>
-    <string name="alert_select_mpd_server_port">Port</string>
+    <string name="hostname">Názov hostiteľa</string>
+    <string name="port">Port</string>
 
     <string name="alert_select_mpd_server_add">Pridať</string>
     <string name="alert_select_mpd_server_save">Uložiť</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -144,8 +144,8 @@
 
     <string name="alert_select_mpd_server">Hangi sunucu?</string>
     <string name="alert_select_mpd_server_name">Sunucu adı</string>
-    <string name="alert_select_mpd_server_hostname">Alan adı</string>
-    <string name="alert_select_mpd_server_port">Port</string>
+    <string name="hostname">Alan adı</string>
+    <string name="port">Port</string>
 
     <string name="alert_select_mpd_server_add">Ekle</string>
     <string name="alert_select_mpd_server_save">Kaydet</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -149,8 +149,8 @@
 
     <string name="alert_select_mpd_server">请选择服务器</string>
     <string name="alert_select_mpd_server_name">服务器名</string>
-    <string name="alert_select_mpd_server_hostname">主机名</string>
-    <string name="alert_select_mpd_server_port">端口</string>
+    <string name="hostname">主机名</string>
+    <string name="port">端口</string>
 
     <string name="alert_select_mpd_server_add">添加</string>
     <string name="alert_select_mpd_server_save">保存</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
     <string name="action_delete">Delete</string>
     <string name="action_delete_history">Delete history</string>
     <string name="action_delete_favorites">Delete favorites</string>
+    <string name="action_ok">OK</string>
     <string name="action_cancel">Cancel</string>
     <string name="action_top_click">TopClick</string>
     <string name="action_top_vote">TopVote</string>
@@ -110,6 +111,12 @@
     <string name="settings_read_timeout">Stream read timeout</string>
     <string name="settings_retry_timeout">Stream retry timeout</string>
     <string name="settings_retry_delay">Reconnects delay</string>
+    <string name="settings_proxy">Proxy</string>
+    <string name="settings_proxy_login">Login</string>
+    <string name="settings_proxy_password">Password</string>
+    <string name="settings_proxy_action_test">Test</string>
+    <string name="settings_proxy_working">Successfully connected to %s</string>
+    <string name="settings_proxy_not_working">Failed to connect to %s\n%s</string>
     <string name="settings_seconds_format">%d seconds</string>
     <string name="settings_milliseconds_format">%d milliseconds</string>
 
@@ -149,8 +156,8 @@
 
     <string name="alert_select_mpd_server">Which server?</string>
     <string name="alert_select_mpd_server_name">Server name</string>
-    <string name="alert_select_mpd_server_hostname">Hostname</string>
-    <string name="alert_select_mpd_server_port">Port</string>
+    <string name="hostname">Hostname</string>
+    <string name="port">Port</string>
 
     <string name="alert_select_mpd_server_add">Add</string>
     <string name="alert_select_mpd_server_save">Save</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -169,6 +169,9 @@
             android:maxLength="8"
             android:summary="@string/settings_milliseconds_format"
             android:title="@string/settings_retry_delay" />
+        <Preference
+            android:key="settings_proxy"
+            android:title="@string/settings_proxy" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/settings_other">


### PR DESCRIPTION
Supported proxies are: HTTP and SOCKS5.
SOCKS4 proxies aren't supported because OkHttp doesn't support them because Android has [issues](https://github.com/square/okhttp/issues/1359) with SOCKS4.

All http requests now made through OkHttp.
All OkHttp instances now share same thread pool.

I have tested this with public proxies and with Orbot. Orbot has [issues](https://github.com/n8fr8/orbot/issues/159) with http proxy but SOCKS works. I haven't tested proxy auth but it should work according to OkHttp documentation.

![radio_droid_proxy_settings](https://user-images.githubusercontent.com/3993671/41823211-f73d75c6-7804-11e8-935a-1530e1a0eb53.png)
