### PR TITLE
a11y: content descriptions for the bottom menu nav items

### DIFF
--- a/app/src/main/res/menu/menu_bottom_navigation.xml
+++ b/app/src/main/res/menu/menu_bottom_navigation.xml
@@ -1,28 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
+<menu xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
             android:id="@+id/nav_item_stations"
             android:icon="@drawable/ic_list_24dp"
-            android:title="@string/nav_item_stations" />
+            android:title="@string/nav_item_stations"
+            app:contentDescription="@string/nav_item_stations" />
 
     <item
             android:id="@+id/nav_item_starred"
             android:icon="@drawable/ic_star_black_24dp"
-            android:title="@string/nav_item_starred" />
+            android:title="@string/nav_item_starred"
+            app:contentDescription="@string/nav_item_starred" />
 
     <item
             android:id="@+id/nav_item_history"
             android:icon="@drawable/ic_restore_black_24dp"
-            android:title="@string/nav_item_history" />
+            android:title="@string/nav_item_history"
+            app:contentDescription="@string/nav_item_history" />
 
     <item
             android:id="@+id/nav_item_alarm"
             android:icon="@drawable/ic_query_builder_black_24dp"
-            android:title="@string/nav_item_alarm" />
+            android:title="@string/nav_item_alarm"
+            app:contentDescription="@string/nav_item_alarm" />
 
     <item
             android:id="@+id/nav_item_settings"
             android:icon="@drawable/ic_tune_24dp"
-            android:title="@string/nav_item_settings" />
+            android:title="@string/nav_item_settings"
+            app:contentDescription="@string/nav_item_settings" />
 
 </menu>


### PR DESCRIPTION
Bottom navigation menu is configured not to show text at all times. Therefore also provide contentDescriptions for those menu items
to make sure screen reader users have something to hear whenever no
titles are showing alongside the icons.