### PR TITLE
Mark notification as non-sensitive

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/PlayerService.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/PlayerService.java
@@ -648,6 +648,7 @@ public class PlayerService extends Service implements RadioPlayer.PlayerListener
                 .setWhen(System.currentTimeMillis())
                 .setTicker(theTicker)
                 .setOngoing(true)
+                .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
                 .setSmallIcon(R.drawable.ic_play_arrow_white_24dp)
                 .setLargeIcon(radioIcon.getBitmap())
                 .addAction(R.drawable.ic_stop_white_24dp, getString(R.string.action_stop), pendingIntentStop);


### PR DESCRIPTION
Set notification visibility to public thus allowing notification to be shown when "Hide sensitive notification content" option is enabled.
Fixes #363 