### PR TITLE
Fix theming of file playlist's load/save dialog

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/ActivityMain.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/ActivityMain.java
@@ -467,7 +467,7 @@ public class ActivityMain extends AppCompatActivity implements SearchView.OnQuer
                 try{
                     if (Utils.verifyStoragePermissions(this)) {
                         SaveFileDialog dialog = new SaveFileDialog();
-                        dialog.setStyle(DialogFragment.STYLE_NO_TITLE, R.style.MyMaterialTheme);
+                        dialog.setStyle(DialogFragment.STYLE_NO_TITLE, Utils.getThemeResId(this));
                         Bundle args = new Bundle();
                         args.putString(FileDialog.EXTENSION, ".m3u"); // file extension is optional
                         dialog.setArguments(args);
@@ -483,7 +483,7 @@ public class ActivityMain extends AppCompatActivity implements SearchView.OnQuer
                 try {
                     if (Utils.verifyStoragePermissions(this)) {
                         OpenFileDialog dialogOpen = new OpenFileDialog();
-                        dialogOpen.setStyle(DialogFragment.STYLE_NO_TITLE, R.style.MyMaterialTheme);
+                        dialogOpen.setStyle(DialogFragment.STYLE_NO_TITLE, Utils.getThemeResId(this));
                         Bundle argsOpen = new Bundle();
                         argsOpen.putString(FileDialog.EXTENSION, ".m3u"); // file extension is optional
                         dialogOpen.setArguments(argsOpen);

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -35,6 +35,10 @@
 
         <item name="iconsInItemBackgroundColor">@color/iconsInItemBackgroundColor</item>
 
+        <item name="met_baseColor">?android:textColorPrimary</item>
+        <item name="met_textColorHint">?android:textColorHint</item>
+        <item name="met_primaryColor">?android:colorPrimary</item>
+
         <!-- workaround for lower API -->
         <item name="colorAccentMy">@color/colorAccent</item>
     </style>
@@ -67,6 +71,10 @@
         <item name="colorTabUnderline">@color/colorTabUnderlineDark</item>
 
         <item name="iconsInItemBackgroundColor">@color/iconsInItemBackgroundColorDark</item>
+
+        <item name="met_baseColor">?android:textColorPrimary</item>
+        <item name="met_textColorHint">?android:textColorHint</item>
+        <item name="met_primaryColor">?android:colorPrimaryDark</item>
 
         <!-- workaround for lower API -->
         <item name="colorAccentMy">@color/colorAccentDark</item>


### PR DESCRIPTION
SaveFileDialog now uses current application theme.
Apply theme colors on MaterialEditText's custom color attributes.
Fixes #364 