### PR TITLE
Implement basic support for android auto

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="net.programmierecke.radiodroid2">
 
     <uses-permission android:name="android.permission.INTERNET" />
@@ -23,10 +24,26 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <!-- Use this intent filter to get voice searches, like "Play The Beatles" -->
+            <intent-filter>
+                <action android:name="android.media.action.MEDIA_PLAY_FROM_SEARCH" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
         </activity>
-        <service android:name="net.programmierecke.radiodroid2.PlayerService">
+        <service
+            android:name="net.programmierecke.radiodroid2.PlayerService">
             <intent-filter>
                 <action android:name="android.intent.action.MEDIA_BUTTON" />
+            </intent-filter>
+        </service>
+
+        <service
+            android:name="net.programmierecke.radiodroid2.RadioDroidBrowserService"
+            android:exported="true"
+            tools:ignore="ExportedService">
+            <intent-filter>
+                <action android:name="android.media.browse.MediaBrowserService" />
             </intent-filter>
         </service>
 
@@ -55,6 +72,14 @@
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
             </intent-filter>
         </receiver>
+
+        <meta-data
+            android:name="com.google.android.gms.car.application"
+            android:resource="@xml/automotive_app_desc" />
+
+        <meta-data
+            android:name="com.google.android.gms.car.notification.SmallIcon"
+            android:resource="@drawable/ic_launcher" />
 
     </application>
 </manifest>

--- a/app/src/main/aidl/net/programmierecke/radiodroid2/IPlayerService.aidl
+++ b/app/src/main/aidl/net/programmierecke/radiodroid2/IPlayerService.aidl
@@ -1,6 +1,7 @@
 package net.programmierecke.radiodroid2;
 
 import net.programmierecke.radiodroid2.data.StreamLiveInfo;
+import android.support.v4.media.session.MediaSessionCompat;
 
 interface IPlayerService
 {
@@ -23,6 +24,7 @@ String getMetadataHomepage();
 int getMetadataBitrate();
 int getMetadataSampleRate();
 int getMetadataChannels();
+MediaSessionCompat.Token getMediaSessionToken();
 boolean isPlaying();
 void startRecording();
 void stopRecording();

--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentPlayer.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentPlayer.java
@@ -17,6 +17,8 @@ import android.widget.*;
 import net.programmierecke.radiodroid2.data.DataRadioStation;
 import net.programmierecke.radiodroid2.data.StreamLiveInfo;
 
+import java.util.List;
+
 import static net.programmierecke.radiodroid2.ActivityMain.FRAGMENT_FROM_BACKSTACK;
 
 public class FragmentPlayer extends Fragment {
@@ -188,13 +190,13 @@ public class FragmentPlayer extends Fragment {
 	private void SetInfoFromHistory(boolean startPlaying) {
         RadioDroidApp radioDroidApp = (RadioDroidApp) getActivity().getApplication();
         HistoryManager historyManager = radioDroidApp.getHistoryManager();
-        DataRadioStation[] history = historyManager.getList();
+        List<DataRadioStation> history = historyManager.getList();
 
-        if(history.length > 0) {
-            DataRadioStation lastStation = history[0];
-            if(startPlaying) {
-				Utils.Play(radioDroidApp.getHttpClient(),lastStation, getContext());
-			} else {
+        if(history.size() > 0) {
+            DataRadioStation lastStation = history.get(0);
+            if(startPlaying)
+                Utils.Play(radioDroidApp.getHttpClient(), lastStation, getContext());
+            else {
                 aTextViewName.setText(lastStation.Name);
 
                 if (!Utils.shouldLoadIcons(getContext()))

--- a/app/src/main/java/net/programmierecke/radiodroid2/MediaSessionCallback.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/MediaSessionCallback.java
@@ -1,0 +1,84 @@
+package net.programmierecke.radiodroid2;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.RemoteException;
+import android.support.v4.content.LocalBroadcastManager;
+import android.support.v4.media.session.MediaSessionCompat;
+import android.view.KeyEvent;
+
+public class MediaSessionCallback extends MediaSessionCompat.Callback {
+    public static final String BROADCAST_PLAY_STATION_BY_ID = "PLAY_STATION_BY_ID";
+    public static final String EXTRA_STATION_ID = "STATION_ID";
+
+    private Context context;
+    private IPlayerService playerService;
+
+    public MediaSessionCallback(Context context, IPlayerService playerService) {
+        this.context = context;
+        this.playerService = playerService;
+    }
+
+    @Override
+    public boolean onMediaButtonEvent(Intent mediaButtonEvent) {
+        final KeyEvent event = mediaButtonEvent.getParcelableExtra(Intent.EXTRA_KEY_EVENT);
+
+        if (event.getKeyCode() == KeyEvent.KEYCODE_HEADSETHOOK) {
+            if (event.getAction() == KeyEvent.ACTION_UP && !event.isLongPress()) {
+                try {
+                    if (playerService.isPlaying()) {
+                        playerService.Pause();
+                    } else {
+                        playerService.Resume();
+                    }
+                } catch (RemoteException e) {
+                    e.printStackTrace();
+                }
+            }
+            return true;
+        } else {
+            return super.onMediaButtonEvent(mediaButtonEvent);
+        }
+    }
+
+    @Override
+    public void onPause() {
+        try {
+            playerService.Pause();
+        } catch (RemoteException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void onPlay() {
+        try {
+            playerService.Resume();
+        } catch (RemoteException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void onStop() {
+        try {
+            playerService.Stop();
+        } catch (RemoteException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void onPlayFromMediaId(String mediaId, Bundle extras) {
+        final String stationId = RadioDroidBrowser.stationIdFromMediaId(mediaId);
+
+        if (!stationId.isEmpty()) {
+            Intent intent = new Intent(BROADCAST_PLAY_STATION_BY_ID);
+            intent.putExtra(EXTRA_STATION_ID, stationId);
+
+            LocalBroadcastManager bm = LocalBroadcastManager.getInstance(context);
+            bm.sendBroadcast(intent);
+        }
+    }
+}

--- a/app/src/main/java/net/programmierecke/radiodroid2/RadioDroidBrowser.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/RadioDroidBrowser.java
@@ -1,0 +1,247 @@
+package net.programmierecke.radiodroid2;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.drawable.Drawable;
+import android.net.Uri;
+import android.os.AsyncTask;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.content.ContextCompat;
+import android.support.v4.media.MediaBrowserCompat;
+import android.support.v4.media.MediaBrowserServiceCompat;
+import android.support.v4.media.MediaDescriptionCompat;
+
+import com.squareup.picasso.NetworkPolicy;
+import com.squareup.picasso.Picasso;
+import com.squareup.picasso.Target;
+
+import net.programmierecke.radiodroid2.data.DataRadioStation;
+
+import java.io.IOException;
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+
+public class RadioDroidBrowser {
+    private static final String MEDIA_ID_ROOT = "__ROOT__";
+    private static final String MEDIA_ID_MUSICS_FAVORITE = "__FAVORITE__";
+    private static final String MEDIA_ID_MUSICS_HISTORY = "__HISTORY__";
+    private static final String MEDIA_ID_MUSICS_TOP = "__TOP__";
+    private static final String MEDIA_ID_MUSICS_TOP_TAGS = "__TOP_TAGS__";
+
+    private static final char LEAF_SEPARATOR = '|';
+
+    private static final int IMAGE_LOAD_TIMEOUT_MS = 2000;
+
+    private RadioDroidApp radioDroidApp;
+
+    private Map<String, DataRadioStation> stationIdToStation = new HashMap<>();
+
+    private static class RetrieveStationsIconAndSendResult extends AsyncTask<Void, Void, Void> {
+        private MediaBrowserServiceCompat.Result<List<MediaBrowserCompat.MediaItem>> result;
+        private List<DataRadioStation> stations;
+        private WeakReference<Context> contextRef;
+
+        private Map<String, Bitmap> stationIdToIcon = new HashMap<>();
+        private CountDownLatch countDownLatch;
+
+        // Picasso stores weak references to targets
+        List<Target> imageLoadTargets = new ArrayList<>();
+
+        RetrieveStationsIconAndSendResult(MediaBrowserServiceCompat.Result<List<MediaBrowserCompat.MediaItem>> result, List<DataRadioStation> stations, Context context) {
+            this.result = result;
+            this.stations = stations;
+            this.contextRef = new WeakReference<>(context);
+        }
+
+        @Override
+        protected void onPreExecute() {
+            countDownLatch = new CountDownLatch(stations.size());
+
+            for (final DataRadioStation station : stations) {
+                Context context = contextRef.get();
+                if (context == null) {
+                    break;
+                }
+
+                Target imageLoadTarget = new Target() {
+                    @Override
+                    public void onBitmapLoaded(Bitmap bitmap, Picasso.LoadedFrom from) {
+                        stationIdToIcon.put(station.ID, bitmap);
+                        countDownLatch.countDown();
+                    }
+
+                    @Override
+                    public void onBitmapFailed(Drawable errorDrawable) {
+                        Context context = contextRef.get();
+                        if (context != null) {
+                            Bitmap placeholderIcon = BitmapFactory.decodeResource(context.getResources(),
+                                    R.drawable.ic_photo_black_24dp);
+                            stationIdToIcon.put(station.ID, placeholderIcon);
+                        }
+
+                        countDownLatch.countDown();
+                    }
+
+                    @Override
+                    public void onPrepareLoad(Drawable placeHolderDrawable) {
+
+                    }
+                };
+                imageLoadTargets.add(imageLoadTarget);
+
+                Picasso.with(context).load(station.IconUrl).into(imageLoadTarget);
+            }
+
+            super.onPreExecute();
+        }
+
+        @Override
+        protected Void doInBackground(Void... voids) {
+            try {
+                countDownLatch.await(IMAGE_LOAD_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+
+            return null;
+        }
+
+
+        @Override
+        protected void onPostExecute(Void aVoid) {
+            Context context = contextRef.get();
+            if (context != null) {
+                for (Target target : imageLoadTargets) {
+                    Picasso.with(context).cancelRequest(target);
+                }
+            }
+
+            List<MediaBrowserCompat.MediaItem> mediaItems = new ArrayList<>();
+
+            for (DataRadioStation station : stations) {
+                Bitmap stationIcon = stationIdToIcon.get(station.ID);
+
+                mediaItems.add(new MediaBrowserCompat.MediaItem(new MediaDescriptionCompat.Builder()
+                        .setMediaId(MEDIA_ID_MUSICS_HISTORY + LEAF_SEPARATOR + station.ID)
+                        .setTitle(station.Name)
+                        .setIconBitmap(stationIcon)
+                        .build(),
+                        MediaBrowserCompat.MediaItem.FLAG_PLAYABLE));
+            }
+
+            result.sendResult(mediaItems);
+
+            super.onPostExecute(aVoid);
+        }
+    }
+
+    public RadioDroidBrowser(RadioDroidApp radioDroidApp) {
+        this.radioDroidApp = radioDroidApp;
+    }
+
+    @Nullable
+    public MediaBrowserServiceCompat.BrowserRoot onGetRoot(@NonNull String clientPackageName, int clientUid, @Nullable Bundle rootHints) {
+        return new MediaBrowserServiceCompat.BrowserRoot(MEDIA_ID_ROOT, null);
+    }
+
+    public void onLoadChildren(@NonNull String parentId, @NonNull MediaBrowserServiceCompat.Result<List<MediaBrowserCompat.MediaItem>> result) {
+        Resources resources = radioDroidApp.getResources();
+        if (MEDIA_ID_ROOT.equals(parentId)) {
+            result.sendResult(createBrowsableMediaItemsForRoot(resources));
+            return;
+        }
+
+        List<MediaBrowserCompat.MediaItem> mediaItems = new ArrayList<>();
+
+        List<DataRadioStation> stations = null;
+
+        switch (parentId) {
+            case MEDIA_ID_MUSICS_FAVORITE: {
+                stations = radioDroidApp.getFavouriteManager().getList();
+                break;
+            }
+            case MEDIA_ID_MUSICS_HISTORY: {
+                stations = radioDroidApp.getHistoryManager().getList();
+                break;
+            }
+            case MEDIA_ID_MUSICS_TOP: {
+
+                break;
+            }
+        }
+
+        if (stations != null && !stations.isEmpty()) {
+            stationIdToStation.clear();
+            for (DataRadioStation station : stations) {
+                stationIdToStation.put(station.ID, station);
+            }
+            result.detach();
+            new RetrieveStationsIconAndSendResult(result, stations, radioDroidApp).execute();
+        } else {
+            result.sendResult(mediaItems);
+        }
+
+    }
+
+    @Nullable
+    public DataRadioStation getStationById(@NonNull String stationId) {
+        return stationIdToStation.get(stationId);
+    }
+
+    private List<MediaBrowserCompat.MediaItem> createBrowsableMediaItemsForRoot(Resources resources) {
+        List<MediaBrowserCompat.MediaItem> mediaItems = new ArrayList<>();
+        mediaItems.add(new MediaBrowserCompat.MediaItem(new MediaDescriptionCompat.Builder()
+                .setMediaId(MEDIA_ID_MUSICS_FAVORITE)
+                .setTitle(resources.getString(R.string.nav_item_starred))
+                .setIconUri(resourceToUri(resources, R.drawable.ic_star_black_24dp))
+                .build(),
+                MediaBrowserCompat.MediaItem.FLAG_BROWSABLE));
+
+        mediaItems.add(new MediaBrowserCompat.MediaItem(new MediaDescriptionCompat.Builder()
+                .setMediaId(MEDIA_ID_MUSICS_HISTORY)
+                .setTitle(resources.getString(R.string.nav_item_history))
+                .setIconUri(resourceToUri(resources, R.drawable.ic_restore_black_24dp))
+                .build(),
+                MediaBrowserCompat.MediaItem.FLAG_BROWSABLE));
+
+        mediaItems.add(new MediaBrowserCompat.MediaItem(new MediaDescriptionCompat.Builder()
+                .setMediaId(MEDIA_ID_MUSICS_TOP)
+                .setTitle(resources.getString(R.string.action_top_click))
+                .setIconUri(resourceToUri(resources, R.drawable.ic_restore_black_24dp))
+                .build(),
+                MediaBrowserCompat.MediaItem.FLAG_BROWSABLE));
+        return mediaItems;
+    }
+
+    public static String stationIdFromMediaId(final String mediaId) {
+        if (mediaId == null) {
+            return "";
+        }
+
+        final int separatorIdx = mediaId.indexOf(LEAF_SEPARATOR);
+
+        if (separatorIdx <= 0) {
+            return "";
+        }
+
+        return mediaId.substring(separatorIdx + 1);
+    }
+
+    private static Uri resourceToUri(Resources resources, int resID) {
+        return Uri.parse(ContentResolver.SCHEME_ANDROID_RESOURCE + "://" +
+                resources.getResourcePackageName(resID) + '/' +
+                resources.getResourceTypeName(resID) + '/' +
+                resources.getResourceEntryName(resID));
+    }
+}

--- a/app/src/main/java/net/programmierecke/radiodroid2/RadioDroidBrowserService.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/RadioDroidBrowserService.java
@@ -1,0 +1,147 @@
+package net.programmierecke.radiodroid2;
+
+import android.content.BroadcastReceiver;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.ServiceConnection;
+import android.os.AsyncTask;
+import android.os.Bundle;
+import android.os.IBinder;
+import android.os.RemoteException;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.content.LocalBroadcastManager;
+import android.support.v4.media.MediaBrowserCompat;
+import android.support.v4.media.MediaBrowserServiceCompat;
+
+import net.programmierecke.radiodroid2.data.DataRadioStation;
+
+import java.lang.ref.WeakReference;
+import java.util.List;
+
+import okhttp3.OkHttpClient;
+
+public class RadioDroidBrowserService extends MediaBrowserServiceCompat {
+    private RadioDroidBrowser radioDroidBrowser;
+    private ServiceConnection playerServiceConnection;
+    private IPlayerService playerService;
+    private GetRealLinkAndPlayTask playTask;
+
+    private static class GetRealLinkAndPlayTask extends AsyncTask<Void, Void, String> {
+        private WeakReference<Context> contextRef;
+        private DataRadioStation station;
+        private WeakReference<IPlayerService> playerServiceRef;
+
+        private OkHttpClient httpClient;
+
+        public GetRealLinkAndPlayTask(Context context, DataRadioStation station, IPlayerService playerService) {
+            this.contextRef = new WeakReference<>(context);
+            this.station = station;
+            this.playerServiceRef = new WeakReference<>(playerService);
+
+            RadioDroidApp radioDroidApp = (RadioDroidApp) context.getApplicationContext();
+            httpClient = radioDroidApp.getHttpClient();
+        }
+
+        @Override
+        protected String doInBackground(Void... params) {
+            Context context = contextRef.get();
+            if (context != null) {
+                return Utils.getRealStationLink(httpClient, context.getApplicationContext(), station.ID);
+            }
+
+            return null;
+        }
+
+        @Override
+        protected void onPostExecute(String result) {
+            IPlayerService playerService = playerServiceRef.get();
+            if (result != null && playerService != null && !isCancelled()) {
+                try {
+                    playerService.SaveInfo(result, station.Name, station.ID, station.IconUrl);
+                    playerService.Play(false);
+                } catch (RemoteException e) {
+                    e.printStackTrace();
+                }
+            }
+            super.onPostExecute(result);
+        }
+    }
+
+
+    private final BroadcastReceiver playStationFromIdReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            String action = intent.getAction();
+            if (MediaSessionCallback.BROADCAST_PLAY_STATION_BY_ID.equals(action)) {
+                String stationId = intent.getStringExtra(MediaSessionCallback.EXTRA_STATION_ID);
+
+                DataRadioStation station = radioDroidBrowser.getStationById(stationId);
+
+                if (station != null) {
+                    if (playTask != null) {
+                        playTask.cancel(false);
+                    }
+
+                    playTask = new GetRealLinkAndPlayTask(context, station, playerService);
+                    playTask.execute();
+                }
+            }
+        }
+    };
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        radioDroidBrowser = new RadioDroidBrowser((RadioDroidApp) getApplication());
+
+        Intent anIntent = new Intent(this, PlayerService.class);
+        startService(anIntent);
+
+        playerServiceConnection = new ServiceConnection() {
+            @Override
+            public void onServiceConnected(ComponentName componentName, IBinder iBinder) {
+                playerService = IPlayerService.Stub.asInterface(iBinder);
+                try {
+                    RadioDroidBrowserService.this.setSessionToken(playerService.getMediaSessionToken());
+                } catch (RemoteException e) {
+                    e.printStackTrace();
+                }
+            }
+
+            @Override
+            public void onServiceDisconnected(ComponentName componentName) {
+                playerService = null;
+            }
+        };
+
+        bindService(anIntent, playerServiceConnection, Context.BIND_AUTO_CREATE);
+
+        IntentFilter filter = new IntentFilter();
+        filter.addAction(MediaSessionCallback.BROADCAST_PLAY_STATION_BY_ID);
+
+        LocalBroadcastManager bm = LocalBroadcastManager.getInstance(this);
+        bm.registerReceiver(playStationFromIdReceiver, filter);
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+
+        unbindService(playerServiceConnection);
+    }
+
+    @Nullable
+    @Override
+    public BrowserRoot onGetRoot(@NonNull String clientPackageName, int clientUid, @Nullable Bundle rootHints) {
+        return radioDroidBrowser.onGetRoot(clientPackageName, clientUid, rootHints);
+    }
+
+    @Override
+    public void onLoadChildren(@NonNull String parentId, @NonNull Result<List<MediaBrowserCompat.MediaItem>> result) {
+        radioDroidBrowser.onLoadChildren(parentId, result);
+    }
+}

--- a/app/src/main/java/net/programmierecke/radiodroid2/StationSaveManager.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/StationSaveManager.java
@@ -99,8 +99,8 @@ public class StationSaveManager {
         return station != null;
     }
 
-    public DataRadioStation[] getList() {
-        return listStations.toArray(new DataRadioStation[0]);
+    public List<DataRadioStation> getList() {
+        return Collections.unmodifiableList(listStations);
     }
 
     public void setChangedListener(IChanged handler){

--- a/app/src/main/res/xml/automotive_app_desc.xml
+++ b/app/src/main/res/xml/automotive_app_desc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<automotiveApp>
+    <uses name="media"/>
+</automotiveApp>


### PR DESCRIPTION
There are many things to do in order to fully support Android Auto but this will be the base of it.
However we should not advertise the support for it since all remaining functionality should be implemented before. 

Also I wasn't able to straightforwardly integrate Top(Vote/Click) lists into Android Auto since their retrieval was too messy and needed heavy refactoring.

Supported:
 History and starred stations lists
 Station icons
 Play/Pause
 Current station/Current song

Not covered by commit:
 Other stations lists
 Any other interactions with station
 Voice commands

![android_auto_lists](https://user-images.githubusercontent.com/3993671/45252839-ffd4b900-b365-11e8-95b6-f75696aeb079.png)
![android_auto_starred](https://user-images.githubusercontent.com/3993671/45252841-ffd4b900-b365-11e8-977d-71187f9d54a3.png)
![android_auto_playing](https://user-images.githubusercontent.com/3993671/45252840-ffd4b900-b365-11e8-98c9-fc01b03cc45c.png)

