### PR TITLE
Fix crash on record opening

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,16 @@
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/MyMaterialTheme">
+        <provider
+            android:authorities="net.programmierecke.radiodroid2.fileprovider"
+            android:name="android.support.v4.content.FileProvider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
+
         <activity
             android:name=".ActivityMain"
             android:label="@string/app_name"

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path name="RecordsFolder" path="." />
+</paths>


### PR DESCRIPTION
Since target sdk is >= 24 - FileProvider should be used to make records
accessible for other apps.

For versions between JELLY_BEAN and LOLLIPOP ClipData workaround is required.
See more at https://commonsware.com/blog/2016/08/31/granting-permissions-uri-intent-extra.html

For lower APIs permissions are just granted for everyone.

Fixes #377 and the same issue reported in comment of #360