### PR TITLE
Prevent RadioDroid from being submitted as Android Auto app

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,10 +36,10 @@
             </intent-filter>
 
             <!-- Use this intent filter to get voice searches, like "Play The Beatles" -->
-            <intent-filter>
-                <action android:name="android.media.action.MEDIA_PLAY_FROM_SEARCH" />
-                <category android:name="android.intent.category.DEFAULT" />
-            </intent-filter>
+            <!--<intent-filter>-->
+                <!--<action android:name="android.media.action.MEDIA_PLAY_FROM_SEARCH" />-->
+                <!--<category android:name="android.intent.category.DEFAULT" />-->
+            <!--</intent-filter>-->
         </activity>
         <service
             android:name="net.programmierecke.radiodroid2.PlayerService">
@@ -83,13 +83,13 @@
             </intent-filter>
         </receiver>
 
-        <meta-data
-            android:name="com.google.android.gms.car.application"
-            android:resource="@xml/automotive_app_desc" />
+        <!--<meta-data-->
+            <!--android:name="com.google.android.gms.car.application"-->
+            <!--android:resource="@xml/automotive_app_desc" />-->
 
-        <meta-data
-            android:name="com.google.android.gms.car.notification.SmallIcon"
-            android:resource="@drawable/ic_launcher" />
+        <!--<meta-data-->
+            <!--android:name="com.google.android.gms.car.notification.SmallIcon"-->
+            <!--android:resource="@drawable/ic_launcher" />-->
 
     </application>
 </manifest>


### PR DESCRIPTION
The feature is still in progress however it was automatically treated
as Android Auto app which prevent it from passing review.

Should fix #389 