### PR TITLE
Fix crash when using domain as host name for proxy

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/Utils.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/Utils.java
@@ -424,7 +424,7 @@ public class Utils {
 			return;
 		}
 
-		InetSocketAddress proxyAddress = new InetSocketAddress(proxySettings.host, proxySettings.port);
+		InetSocketAddress proxyAddress = InetSocketAddress.createUnresolved(proxySettings.host, proxySettings.port);
 		Proxy proxy = new Proxy(proxySettings.type, proxyAddress);
 
 		builder.proxy(proxy);


### PR DESCRIPTION
Using domain resulted in attempt to resolve it via DNS in main thread
which resulted in NetworkOnMainThreadException.

Use InetSocketAddress.createUnresolved instead.

Fixes #419