### PR TITLE
Fix "resume within" setting not being used

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/ExoPlayerWrapper.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/ExoPlayerWrapper.java
@@ -235,7 +235,7 @@ public class ExoPlayerWrapper implements PlayerWrapper, IcyDataSource.IcyDataSou
         stateListener.onPlayerError(R.string.error_stream_reconnect_timeout);
 
         SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(context);
-        int resumeWithin = sharedPref.getInt("resume_within", 60);
+        int resumeWithin = sharedPref.getInt("settings_resume_within", 60);
         if(resumeWithin > 0) {
             Log.d(TAG, "Trying to resume playback within " + resumeWithin + "s.");
             player.setPlayWhenReady(false);


### PR DESCRIPTION
The key in preferences.xml is "settings_resume_within" and not
"resume_within".  Because of that, the settings value was ignored and
the default value of 60s was always used.