### PR TITLE
Update notification only on icy title changes

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/PlayerService.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/PlayerService.java
@@ -913,6 +913,7 @@ public class PlayerService extends Service implements RadioPlayer.PlayerListener
 
     @Override
     public void foundLiveStreamInfo(StreamLiveInfo liveInfo) {
+        StreamLiveInfo oldLiveInfo = this.liveInfo;
         this.liveInfo = liveInfo;
 
         if (BuildConfig.DEBUG) {
@@ -922,7 +923,9 @@ public class PlayerService extends Service implements RadioPlayer.PlayerListener
             }
         }
 
-        sendBroadCast(PLAYER_SERVICE_META_UPDATE);
-        updateNotification();
+        if (oldLiveInfo == null || !oldLiveInfo.getTitle().equals(liveInfo.getTitle())) {
+            sendBroadCast(PLAYER_SERVICE_META_UPDATE);
+            updateNotification();
+        }
     }
 }


### PR DESCRIPTION
Some radio stations seem to send time stamps or unchanged data every
second. So don't waste battery on updating metadata and notifications if
nothing relevant has happened and don't reset the start time either.

Fixes #464 largely.