### PR TITLE
Fix auto-play-on-start related NPE

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentPlayer.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentPlayer.java
@@ -350,7 +350,9 @@ public class FragmentPlayer extends Fragment {
 
 		@Override
 		public void onActivityStarted(Activity activity) {
-			if (PreferenceManager.getDefaultSharedPreferences(getContext().getApplicationContext()).getBoolean("auto_play_on_startup", false)) {
+			boolean startPlaying = getContext() != null
+					&& PreferenceManager.getDefaultSharedPreferences(getContext().getApplicationContext()).getBoolean("auto_play_on_startup", false);
+			if (startPlaying) {
 				SetInfoFromHistory(true);
 			}
 		}


### PR DESCRIPTION
If no context is defined in onActivityStarted yet, auto-play will be
considered later in onActivityCreated.

Fixes #468