### PR TITLE
Always use a fallback icon if no station icon is configured

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/PlayerService.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/PlayerService.java
@@ -786,8 +786,11 @@ public class PlayerService extends Service implements RadioPlayer.PlayerListener
     private void downloadRadioIcon() {
         final float px = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 70, getResources().getDisplayMetrics());
 
-        if (currentStationIconUrl == null) return;
-        if (currentStationIconUrl.trim().equals("")) return;
+        if (currentStationIconUrl == null || currentStationIconUrl.trim().equals("")) {
+            radioIcon = (BitmapDrawable) ResourcesCompat.getDrawable(getResources(), R.drawable.ic_launcher, null);
+            updateNotification();
+            return;
+        }
 
         Picasso.with(getApplicationContext())
                 .load(currentStationIconUrl)

--- a/app/src/main/java/net/programmierecke/radiodroid2/PlayerServiceUtil.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/PlayerServiceUtil.java
@@ -230,7 +230,10 @@ public class PlayerServiceUtil {
     public static void getStationIcon(final ImageView holder, String fromUrl) {
         final String iconUrl = fromUrl != null? fromUrl : getStationIconUrl();
         if (iconUrl != null) {
-            if (iconUrl.trim().equals("")) return;
+            if (iconUrl.trim().equals("")) {
+                holder.setImageDrawable(ContextCompat.getDrawable(mainContext, R.drawable.ic_photo_black_24dp));
+                return;
+            }
             Resources r = mainContext.getResources();
             final float px = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 70, r.getDisplayMetrics());
 


### PR DESCRIPTION
Otherwise the icon of the previous station stays displayed.

Fixes #470