### PR TITLE
Get rid of left padding in preferences (fixes #491)

### DIFF
--- a/app/src/main/res/values-sw360dp-v13/values-preference.xml
+++ b/app/src/main/res/values-sw360dp-v13/values-preference.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <bool name="config_materialPreferenceIconSpaceReserved" tools:ignore="MissingDefaultResource,PrivateResource">false</bool>
+    <dimen name="preference_category_padding_start" tools:ignore="MissingDefaultResource,PrivateResource">0dp</dimen>
+</resources>


### PR DESCRIPTION
See
https://stackoverflow.com/questions/51518758/preferencefragmentcompat-has-padding-on-preferencecategory-that-i-cant-get-rid

Fixes #491