### PR TITLE
Upgrade androidx preference library to 1.1.0-alpha05

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
     implementation 'com.google.android.material:material:1.0.0'
-    implementation 'androidx.preference:preference:1.0.0'
+    implementation 'androidx.preference:preference:1.1.0-alpha05'
     implementation 'androidx.mediarouter:mediarouter:1.0.0'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'com.squareup.okhttp3:okhttp:3.12.1'


### PR DESCRIPTION
Fixes primary color in settings not correctly applied in dark mode after
recreate, resulting in black on dark grey text.

See
https://stackoverflow.com/questions/53921023/preferencefragmentcompat-wont-change-color-when-change-theme-and-recreate-activ

(To test this, toggle "Use circular icons" or "Bottom navigation" in
dark mode.)