### PR TITLE
Redesign settings layout

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,6 +59,7 @@ android {
 }
 
 dependencies {
+    implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation 'androidx.recyclerview:recyclerview:1.0.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,6 +23,7 @@ android {
         versionCode 85
         versionName "0.75"
 
+        multiDexEnabled true
         vectorDrawables.useSupportLibrary = true
 
         // Define your application name here.
@@ -70,6 +71,9 @@ dependencies {
     implementation 'com.jakewharton.picasso:picasso2-okhttp3-downloader:1.1.0'
     implementation 'jp.wasabeef:picasso-transformations:2.2.1'
     implementation 'com.google.android.exoplayer:exoplayer:2.9.6'
+    implementation "com.mikepenz:iconics-core:4.0.0"
+    implementation 'com.mikepenz:google-material-typeface:3.0.1.4.original-kotlin@aar'
+    implementation 'com.mikepenz:community-material-typeface:3.5.95.1-kotlin@aar'
     implementation 'com.github.rustamg:file-dialogs:1.0'
     implementation 'info.debatty:java-string-similarity:1.2.1'
     playImplementation 'com.google.android.gms:play-services-cast:16.2.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -76,6 +76,7 @@ dependencies {
     implementation 'com.mikepenz:community-material-typeface:3.5.95.1-kotlin@aar'
     implementation 'com.github.rustamg:file-dialogs:1.0'
     implementation 'info.debatty:java-string-similarity:1.2.1'
+    implementation 'com.github.ByteHamster:SearchPreference:v1.2.5'
     playImplementation 'com.google.android.gms:play-services-cast:16.2.0'
     playImplementation 'com.google.android.gms:play-services-cast-framework:16.2.0'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
     implementation 'com.google.android.material:material:1.0.0'
-    implementation 'androidx.preference:preference:1.1.0-alpha05'
+    implementation 'androidx.preference:preference:1.1.0-beta01'
     implementation 'androidx.mediarouter:mediarouter:1.0.0'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'com.squareup.okhttp3:okhttp:3.12.1'

--- a/app/src/main/java/net/programmierecke/radiodroid2/ActivityMain.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/ActivityMain.java
@@ -221,6 +221,7 @@ public class ActivityMain extends AppCompatActivity implements SearchView.OnQuer
             default:
         }
 
+        mFragmentManager.popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE);
         FragmentTransaction fragmentTransaction = mFragmentManager.beginTransaction();
         if (Utils.bottomNavigationEnabled(this))
             fragmentTransaction.replace(R.id.containerView, f).commit();
@@ -761,6 +762,7 @@ public class ActivityMain extends AppCompatActivity implements SearchView.OnQuer
                 break;
             }
         }
+
         if (mpd_port == 0 || !MPDClient.connected)
             return super.onKeyUp(keyCode, event);
 

--- a/app/src/main/java/net/programmierecke/radiodroid2/ActivityMain.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/ActivityMain.java
@@ -11,6 +11,9 @@ import android.content.pm.PackageManager;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Handler;
+
+import com.bytehamster.lib.preferencesearch.SearchPreferenceResult;
+import com.bytehamster.lib.preferencesearch.SearchPreferenceResultListener;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.android.material.navigation.NavigationView;
 
@@ -25,6 +28,7 @@ import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.appcompat.app.ActionBarDrawerToggle;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceManager;
 import androidx.appcompat.widget.SearchView;
 import androidx.appcompat.widget.Toolbar;
@@ -62,7 +66,7 @@ import okhttp3.OkHttpClient;
 
 import static net.programmierecke.radiodroid2.MediaSessionCallback.EXTRA_STATION_UUID;
 
-public class ActivityMain extends AppCompatActivity implements SearchView.OnQueryTextListener, IMPDClientStatusChange, NavigationView.OnNavigationItemSelectedListener, BottomNavigationView.OnNavigationItemSelectedListener, FileDialog.OnFileSelectedListener, TimePickerDialog.OnTimeSetListener {
+public class ActivityMain extends AppCompatActivity implements SearchView.OnQueryTextListener, IMPDClientStatusChange, NavigationView.OnNavigationItemSelectedListener, BottomNavigationView.OnNavigationItemSelectedListener, FileDialog.OnFileSelectedListener, TimePickerDialog.OnTimeSetListener, SearchPreferenceResultListener {
 
     public static final String EXTRA_SEARCH_TAG = "search_tag";
 
@@ -244,6 +248,10 @@ public class ActivityMain extends AppCompatActivity implements SearchView.OnQuer
         if (backStackCount > 0) {
             // FRAGMENT_FROM_BACKSTACK value added as a backstack name for non-root fragments like Recordings, About, etc
             backStackEntry = mFragmentManager.getBackStackEntryAt(mFragmentManager.getBackStackEntryCount() - 1);
+            if (backStackEntry.getName().equals("SearchPreferenceFragment")) {
+                super.onBackPressed();
+                return;
+            }
             int parsedId = Integer.parseInt(backStackEntry.getName());
             if (parsedId == FRAGMENT_FROM_BACKSTACK) {
                 super.onBackPressed();
@@ -486,10 +494,12 @@ public class ActivityMain extends AppCompatActivity implements SearchView.OnQuer
                 myToolbar.setTitle(R.string.nav_item_alarm);
                 break;
             }
+ /* settings fragment sets the toolbar title depending on the current preference screen
             case R.id.nav_item_settings: {
                 myToolbar.setTitle(R.string.nav_item_settings);
                 break;
             }
+ */
         }
 
         MenuItem mediaRouteMenuItem = CastHandler.getRouteItem(getApplicationContext(), menu);
@@ -903,5 +913,13 @@ public class ActivityMain extends AppCompatActivity implements SearchView.OnQuer
 
     public final Toolbar getToolbar() {
         return (Toolbar) findViewById(R.id.my_awesome_toolbar);
+    }
+
+    @Override
+    public void onSearchResultClicked(SearchPreferenceResult result) {
+        result.closeSearchPage(this);
+        getSupportFragmentManager().popBackStack();
+        FragmentSettings f = FragmentSettings.openNewSettingsSubFragment(this, result.getScreen());
+        result.highlight(f, Utils.getAccentColor(this));
     }
 }

--- a/app/src/main/java/net/programmierecke/radiodroid2/ActivityMain.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/ActivityMain.java
@@ -13,6 +13,8 @@ import android.os.Bundle;
 import android.os.Handler;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.android.material.navigation.NavigationView;
+
+import androidx.core.view.LayoutInflaterCompat;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
@@ -38,6 +40,8 @@ import android.widget.TextView;
 import android.widget.TimePicker;
 import android.widget.Toast;
 
+import com.mikepenz.iconics.Iconics;
+import com.mikepenz.iconics.context.IconicsLayoutInflater2;
 import com.rustamg.filedialogs.FileDialog;
 import com.rustamg.filedialogs.OpenFileDialog;
 import com.rustamg.filedialogs.SaveFileDialog;
@@ -116,6 +120,9 @@ public class ActivityMain extends AppCompatActivity implements SearchView.OnQuer
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        Iconics.init(this);
+        LayoutInflaterCompat.setFactory2(getLayoutInflater(), new IconicsLayoutInflater2(getDelegate()));
+
         super.onCreate(savedInstanceState);
         Intent intent = getIntent();
         onNewIntent(intent);

--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentSettings.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentSettings.java
@@ -11,6 +11,7 @@ import android.os.Bundle;
 
 import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
+import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.FragmentTransaction;
 import androidx.appcompat.app.AlertDialog;
 import androidx.preference.ListPreference;
@@ -29,6 +30,8 @@ import android.widget.Toast;
 
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial;
 import com.mikepenz.iconics.typeface.library.googlematerial.GoogleMaterial;
+import com.bytehamster.lib.preferencesearch.SearchConfiguration;
+import com.bytehamster.lib.preferencesearch.SearchPreference;
 
 import net.programmierecke.radiodroid2.data.MPDServer;
 import net.programmierecke.radiodroid2.interfaces.IApplicationSelected;
@@ -45,8 +48,6 @@ import static net.programmierecke.radiodroid2.ActivityMain.FRAGMENT_FROM_BACKSTA
 import static net.programmierecke.radiodroid2.Utils.parseIntWithDefault;
 
 public class FragmentSettings extends PreferenceFragmentCompat implements SharedPreferences.OnSharedPreferenceChangeListener, IApplicationSelected, PreferenceFragmentCompat.OnPreferenceStartScreenCallback  {
-
-    private PreferenceScreen superordinatePreferenceScreen;
 
     @Override
     public Fragment getCallbackFragment() {
@@ -114,7 +115,10 @@ public class FragmentSettings extends PreferenceFragmentCompat implements Shared
         refreshToolbar();
         if (s == null) {
             refreshToplevelIcons();
-
+            SearchPreference searchPreference = (SearchPreference) findPreference("searchPreference");
+            SearchConfiguration config = searchPreference.getSearchConfiguration();
+            config.setActivity((AppCompatActivity) getActivity());
+            config.index(R.xml.preferences);
         } else if (s.equals("pref_category_player")) {
             findPreference("equalizer").setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
                 @Override

--- a/app/src/main/java/net/programmierecke/radiodroid2/RadioDroidApp.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/RadioDroidApp.java
@@ -4,6 +4,7 @@ import android.app.Application;
 import android.content.SharedPreferences;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatDelegate;
+import androidx.multidex.MultiDexApplication;
 import androidx.preference.PreferenceManager;
 
 import com.jakewharton.picasso.OkHttp3Downloader;
@@ -21,7 +22,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 
-public class RadioDroidApp extends Application {
+public class RadioDroidApp extends MultiDexApplication {
 
     private HistoryManager historyManager;
     private FavouriteManager favouriteManager;

--- a/app/src/main/java/net/programmierecke/radiodroid2/Utils.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/Utils.java
@@ -10,6 +10,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
+import android.graphics.Color;
 import android.media.AudioManager;
 import android.media.ToneGenerator;
 import android.net.ConnectivityManager;
@@ -22,10 +23,16 @@ import androidx.core.content.ContextCompat;
 import androidx.preference.PreferenceManager;
 import android.text.TextUtils;
 import android.util.Log;
+import android.util.TypedValue;
 import android.widget.Toast;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import com.mikepenz.iconics.IconicsColor;
+import com.mikepenz.iconics.IconicsDrawable;
+import com.mikepenz.iconics.IconicsSize;
+import com.mikepenz.iconics.typeface.IIcon;
+
 import net.programmierecke.radiodroid2.data.DataRadioStation;
 
 import net.programmierecke.radiodroid2.data.MPDServer;
@@ -418,6 +425,21 @@ public class Utils {
 		return builder.toString();
 	}
 
+    public static int themeAttributeToColor(int themeAttributeId, Context context, int fallbackColorId) {
+        TypedValue outValue = new TypedValue();
+        Resources.Theme theme = context.getTheme();
+        boolean wasResolved = theme.resolveAttribute(themeAttributeId, outValue, true);
+        if (wasResolved) {
+            return outValue.resourceId == 0 ? outValue.data : ContextCompat.getColor(context, outValue.resourceId);
+        } else {
+            return fallbackColorId;
+        }
+    }
+
+    public static int getIconColor(Context context) {
+        return themeAttributeToColor(R.attr.menuTextColorDefault, context, Color.LTGRAY);
+    }
+
 	public static void setOkHttpProxy(@NonNull OkHttpClient.Builder builder, @NonNull final ProxySettings proxySettings) {
 		if (TextUtils.isEmpty(proxySettings.host)) {
 			return;
@@ -452,5 +474,9 @@ public class Utils {
                 resources.getResourcePackageName(resID) + '/' +
                 resources.getResourceTypeName(resID) + '/' +
                 resources.getResourceEntryName(resID));
+    }
+
+    public static IconicsDrawable IconicsIcon(Context context, IIcon icon) {
+        return new IconicsDrawable(context, icon).size(IconicsSize.TOOLBAR_ICON_SIZE).padding(IconicsSize.TOOLBAR_ICON_PADDING).color(IconicsColor.colorInt(getIconColor(context)));
     }
 }

--- a/app/src/main/java/net/programmierecke/radiodroid2/Utils.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/Utils.java
@@ -440,6 +440,10 @@ public class Utils {
         return themeAttributeToColor(R.attr.menuTextColorDefault, context, Color.LTGRAY);
     }
 
+	public static int getAccentColor(Context context) {
+		return themeAttributeToColor(R.attr.colorAccent, context, Color.LTGRAY);
+	}
+
 	public static void setOkHttpProxy(@NonNull OkHttpClient.Builder builder, @NonNull final ProxySettings proxySettings) {
 		if (TextUtils.isEmpty(proxySettings.host)) {
 			return;

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -36,7 +36,6 @@
     <string name="sleep_timer" formatted="true">Časovač před spaním: %1$02d:%2$02d</string>
     <string name="nav_item_add_sleep">+15 min</string>
 
-    <string name="settings_general">Všeobecné</string>
     <string name="settings_single_use_tags">Zobrazit osamocené tagy</string>
     <string name="settings_single_use_tags_desc_off">Tagy použité pouze jednou nebudou zobrazeny</string>
     <string name="settings_single_use_tags_desc_on">Tagy použité pouze jednou budou zobrazeny</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -63,7 +63,6 @@
     <string name="label_button_cancel">Annullere</string>
     <string name="label_button_overwrite">Overskrive</string>
 
-    <string name="settings_interface">UI</string>
     <string name="settings_theme_selection_title">Tema</string>
     <string name="theme_light">Lys</string>
     <string name="theme_dark">Mørk</string>
@@ -73,7 +72,6 @@
     <string name="settings_compact_style_desc_on">Lille ikon ikke tilføjet station detaljer</string>
     <string name="settings_bottom_navigation">Bundnavigation</string>
 
-    <string name="settings_general">Generelt</string>
     <string name="settings_single_use_tags">Vise sjældne brugte mærker</string>
     <string name="settings_single_use_tags_desc_off">Sjældne brugte mærker vises ikke</string>
     <string name="settings_single_use_tags_desc_on">Sjældne brugte mærker vises</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -46,14 +46,12 @@
     <string name="nav_item_save_playlist">In Playlist speichern</string>
     <string name="nav_item_load_playlist">Von Playlist laden</string>
 
-    <string name="settings_interface">UI</string>
     <string name="settings_theme_selection_title">Thema</string>
     <string name="theme_light">Hell</string>
     <string name="theme_dark">Dunkel</string>
     <string name="settings_circular_icons">Runde Icons benutzen</string>
     <string name="settings_compact_style">Kompakter Modus</string>
 
-    <string name="settings_general">Allgemein</string>
     <string name="settings_single_use_tags">Tag-Anzeigefilter</string>
     <string name="settings_single_use_tags_desc_off">Nur einmal vorkommende Tags werden nicht angezeigt.</string>
     <string name="settings_single_use_tags_desc_on">Alle Tags werden angezeigt, auch nur einmal vorkommende.</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -70,7 +70,6 @@
     <string name="sleep_timer_clear">Καθάρισμα</string>
     <string name="nav_item_add_sleep">+15 λεπτά</string>
 
-    <string name="settings_interface">Περιβάλλον Χρήστη</string>
     <string name="settings_theme_selection_title">Θέμα</string>
     <string name="theme_light">Φωτεινό</string>
     <string name="theme_dark">Σκοτεινό</string>
@@ -78,7 +77,6 @@
     <string name="settings_compact_style">Συμπαγής κατάσταση λειτουργίας</string>
     <string name="settings_bottom_navigation">Τα χειριστήρια κάτω</string>
 
-    <string name="settings_general">Γενικά</string>
     <string name="settings_single_use_tags">Καρτέλες μονής χρήσης</string>
     <string name="settings_single_use_tags_desc_off">Οι καρτέλες μοναδικής χρήσης δεν θα εμφανίζονται</string>
     <string name="settings_single_use_tags_desc_on">Οι καρτέλες μοναδικής χρήσης θα εμφανίζονται</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -55,7 +55,6 @@
     <string name="nav_item_save_playlist">Guardar en lista de reproducción</string>
     <string name="nav_item_load_playlist">Cargar desde lista de reproducción</string>
 
-    <string name="settings_interface">UI</string>
     <string name="settings_theme_selection_title">Tema</string>
     <string name="theme_light">Claro</string>
     <string name="theme_dark">Oscuro</string>
@@ -63,7 +62,6 @@
     <string name="settings_compact_style">Modo compacto</string>
     <string name="settings_bottom_navigation">Navegación en parte inferior</string>
 
-    <string name="settings_general">General</string>
     <string name="settings_single_use_tags">Mostrar etiquetas poco usadas</string>
     <string name="settings_single_use_tags_desc_off">Las etiquetas poco usadas no se mostrarán</string>
     <string name="settings_single_use_tags_desc_on">Las etiquetas poco usadas se mostrarán</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -37,7 +37,6 @@
     <string name="sleep_timer" formatted="true">Uniajastin: %1$02d:%2$02d</string>
     <string name="nav_item_add_sleep">+15 min</string>
 
-    <string name="settings_general">Yleiset</string>
     <string name="settings_single_use_tags">Kertakäyttöiset tunnisteet</string>
     <string name="settings_single_use_tags_desc_off">Älä näytä kertakäyttöisiä tunnisteita</string>
     <string name="settings_single_use_tags_desc_on">Näytä kertakäyttöiset tunnisteet</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -60,14 +60,12 @@
     <string name="sleep_timer_clear">Effacer</string>
     <string name="nav_item_add_sleep">+15 mins</string>
 
-    <string name="settings_interface">UI</string>
     <string name="settings_theme_selection_title">Thème</string>
     <string name="theme_light">Clair</string>
     <string name="theme_dark">Noir</string>
     <string name="settings_circular_icons">Utiliser des icônes circulaires</string>
     <string name="settings_compact_style">Mode compact</string>
 
-    <string name="settings_general">Général</string>
     <string name="settings_single_use_tags">Montrer les tags uniques</string>
     <string name="settings_single_use_tags_desc_off">Les tags uniques ne seront pas affichés</string>
     <string name="settings_single_use_tags_desc_on">Les tags uniques seront affichés</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -54,7 +54,6 @@
     <string name="nav_item_save_playlist">Mentés lejátzólistára</string>
     <string name="nav_item_load_playlist">Betöltés lejátszólistából</string>
 
-    <string name="settings_interface">Felület</string>
     <string name="settings_theme_selection_title">Téma</string>
     <string name="theme_light">Világos</string>
     <string name="theme_dark">Sötét</string>
@@ -62,7 +61,6 @@
     <string name="settings_compact_style">Kompakt mód</string>
     <string name="settings_bottom_navigation">Alsó navigáció</string>
 
-    <string name="settings_general">Általános</string>
     <string name="settings_single_use_tags">Egyszer használt címkék megjelenítése</string>
     <string name="settings_single_use_tags_desc_off">Az egyszer használt címkék nem jelennek meg</string>
     <string name="settings_single_use_tags_desc_on">Az egyszer használt címkék megjelennek</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -73,7 +73,6 @@
     <string name="label_button_cancel">Batal</string>
     <string name="label_button_overwrite">Menimpa</string>
 
-    <string name="settings_interface">UI</string>
     <string name="settings_theme_selection_title">Tema</string>
     <string name="theme_light">Terang</string>
     <string name="theme_dark">Gelap</string>
@@ -83,7 +82,6 @@
     <string name="settings_compact_style_desc_on">Diadaptasikan ikon kecil tanpa detil stasiun</string>
     <string name="settings_bottom_navigation">Navigasi bawah</string>
 
-    <string name="settings_general">Umum</string>
     <string name="settings_single_use_tags">Tampilkan penggunaan tag langka</string>
     <string name="settings_single_use_tags_desc_off">Penggunaan tag langka tidak akan ditampilkan</string>
     <string name="settings_single_use_tags_desc_on">Penggunaan tag langka ditampilkan</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -55,7 +55,6 @@
     <string name="nav_item_save_playlist">Opslaan naar afspeellijst</string>
     <string name="nav_item_load_playlist">Laden uit afspeellijst</string>
 
-    <string name="settings_interface">Uiterlijk</string>
     <string name="settings_theme_selection_title">Thema</string>
     <string name="theme_light">Licht</string>
     <string name="theme_dark">Donker</string>
@@ -63,7 +62,6 @@
     <string name="settings_compact_style">Compacte modus</string>
     <string name="settings_bottom_navigation">Navigatiebalk onderaan</string>
 
-    <string name="settings_general">Algemeen</string>
     <string name="settings_single_use_tags">Eenmalige gebruikslabels tonen</string>
     <string name="settings_single_use_tags_desc_off">Eenmalige gebruikslabels worden getoond</string>
     <string name="settings_single_use_tags_desc_on">Eenmalige gebruikslabels worden niet getoond</string>

--- a/app/src/main/res/values-nn/strings.xml
+++ b/app/src/main/res/values-nn/strings.xml
@@ -46,14 +46,12 @@
   <string name="nav_item_add_sleep">+15 min</string>
   <string name="nav_item_save_playlist">Lagra til speleliste</string>
   <string name="nav_item_load_playlist">Last frå speleliste</string>
-  <string name="settings_interface">Brukargrensesnitt</string>
   <string name="settings_theme_selection_title">Tema</string>
   <string name="theme_light">Lyst</string>
   <string name="theme_dark">Mørkt</string>
   <string name="settings_circular_icons">Bruk sirkelforma kanalbilete</string>
   <string name="settings_compact_style">Kompakt vising</string>
   <string name="settings_bottom_navigation">Navigeringspanel heilt nede</string>
-  <string name="settings_general">Generelt</string>
   <string name="settings_single_use_tags">Vis òg merkelappar som berre er brukte éin gong</string>
   <string name="settings_single_use_tags_desc_off">Merkelappar berre brukte éin gong vert ikkje viste</string>
   <string name="settings_single_use_tags_desc_on">Merkelappar berre brukte éin gong vert viste</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -61,7 +61,6 @@
     <string name="label_button_cancel">Anuluj</string>
     <string name="label_button_overwrite">Zastąp</string>
 
-    <string name="settings_interface">Interfejs Użytkownika</string>
     <string name="settings_theme_selection_title">Wygląd</string>
     <string name="theme_light">Jasny</string>
     <string name="theme_dark">Ciemny</string>
@@ -71,7 +70,6 @@
     <string name="settings_compact_style_desc_on">Mała ikona przejęta bez szczegółów stacji</string>
     <string name="settings_bottom_navigation">Dolny pasek nawigacji</string>
 
-    <string name="settings_general">Ogólne</string>
     <string name="settings_single_use_tags">Pokaż rzadko używane tagi</string>
     <string name="settings_single_use_tags_desc_off">Tagi rzadko używane nie będą wyświetlane</string>
     <string name="settings_single_use_tags_desc_on">Tagi rzadko używane zostaną wyświetlone</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -46,7 +46,6 @@
     <string name="sleep_timer_clear">Очистить</string>
     <string name="nav_item_add_sleep">Таймер на отключение</string>
 
-    <string name="settings_interface">Интерфейс</string>
     <string name="settings_theme_selection_title">Тема</string>
     <string name="theme_light">Светлая</string>
     <string name="theme_dark">Тёмная</string>
@@ -54,7 +53,6 @@
     <string name="settings_compact_style">Компактный режим</string>
     <string name="settings_bottom_navigation">Панель навигации внизу</string>
 
-    <string name="settings_general">Общие</string>
     <string name="settings_single_use_tags">Одиночные теги</string>
     <string name="settings_single_use_tags_desc_off">Теги, использованные единожды, не будут показаны</string>
     <string name="settings_single_use_tags_desc_on">Теги, использованные единожды, будут показаны</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -65,7 +65,6 @@
     <string name="sleep_timer_clear">Vynulovať</string>
     <string name="nav_item_add_sleep">+15 minút</string>
 
-    <string name="settings_interface">Rozhranie</string>
     <string name="settings_theme_selection_title">Vzhľad</string>
     <string name="theme_light">Svetlý</string>
     <string name="theme_dark">Tmavý</string>
@@ -73,7 +72,6 @@
     <string name="settings_compact_style">Kompaktný režim</string>
     <string name="settings_bottom_navigation">Navigácia na spodku obrazovky</string>
 
-    <string name="settings_general">Všeobecné</string>
     <string name="settings_single_use_tags">Zobraziť značky použité len raz</string>
     <string name="settings_single_use_tags_desc_off">Značky použité len raz nebudú zobrazené</string>
     <string name="settings_single_use_tags_desc_on">Značky použité len raz budú zobrazené</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -54,7 +54,6 @@
     <string name="nav_item_save_playlist">Oynatma listesine kaydet</string>
     <string name="nav_item_load_playlist">Oynatma listesinden yükle</string>
 
-    <string name="settings_interface">Arayüz</string>
     <string name="settings_theme_selection_title">Tema</string>
     <string name="theme_light">Aydınlık</string>
     <string name="theme_dark">Karanlık</string>
@@ -62,7 +61,6 @@
     <string name="settings_compact_style">Sıkışık düzen</string>
     <string name="settings_bottom_navigation">Alt gezinme</string>
 
-    <string name="settings_general">Genel</string>
     <string name="settings_single_use_tags">Tek kullanım etiketleri göster</string>
     <string name="settings_single_use_tags_desc_off">Tek kullanım etiketler gösterilmeyecek</string>
     <string name="settings_single_use_tags_desc_on">Tek kullanım etiketler gösterilecek</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -65,7 +65,6 @@
     <string name="label_button_cancel">取消</string>
     <string name="label_button_overwrite">覆盖</string>
 
-    <string name="settings_interface">界面</string>
     <string name="settings_theme_selection_title">主题</string>
     <string name="theme_light">亮色</string>
     <string name="theme_dark">暗色</string>
@@ -75,7 +74,6 @@
     <string name="settings_compact_style_desc_on">使用小图标并隐藏电台详情</string>
     <string name="settings_bottom_navigation">底部导航栏</string>
 
-    <string name="settings_general">常规</string>
     <string name="settings_single_use_tags">显示不常用标签</string>
     <string name="settings_single_use_tags_desc_off">不显示不常用标签</string>
     <string name="settings_single_use_tags_desc_on">显示不常用标签</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,7 +65,7 @@
     <string name="label_button_cancel">Cancel</string>
     <string name="label_button_overwrite">Overwrite</string>
 
-    <string name="settings_interface">UI</string>
+    <string name="settings_appearance">Appearance</string>
     <string name="settings_theme_selection_title">Theme</string>
     <string name="theme_light">Light</string>
     <string name="theme_dark">Dark</string>
@@ -75,7 +75,7 @@
     <string name="settings_compact_style_desc_on">Small icon adopted without station details</string>
     <string name="settings_bottom_navigation">Bottom navigation</string>
 
-    <string name="settings_general">General</string>
+    <string name="settings_interaction">Interaction</string>
     <string name="settings_single_use_tags">Show rarely-used tags</string>
     <string name="settings_single_use_tags_desc_off">Rarely-used tags will not be shown</string>
     <string name="settings_single_use_tags_desc_on">Rarely-used tags will be shown</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -7,6 +7,7 @@
     <com.bytehamster.lib.preferencesearch.SearchPreference android:key="searchPreference" />
 
   <PreferenceScreen android:title="@string/settings_appearance"
+        search:ignore="true"
         android:key="pref_category_ui">
 
         <ListPreference
@@ -38,6 +39,7 @@
     </PreferenceScreen>
 
     <PreferenceScreen android:title="@string/settings_interaction"
+        search:ignore="true"
         android:key="pref_category_interaction">
 
         <ListPreference
@@ -95,6 +97,7 @@
     </PreferenceScreen>
 
     <PreferenceScreen android:title="@string/settings_play"
+        search:ignore="true"
         android:key="pref_category_player">
 
         <CheckBoxPreference
@@ -124,6 +127,7 @@
     </PreferenceScreen>
 
     <PreferenceScreen android:title="@string/settings_alarm"
+        search:ignore="true"
         android:key="pref_category_alarm">
 
         <CheckBoxPreference
@@ -151,6 +155,7 @@
     </PreferenceScreen>
 
     <PreferenceScreen android:title="@string/settings_recordings"
+        search:ignore="true"
         android:key="pref_category_recordings">
         <ListPreference
             android:defaultValue="@string/settings_record_name_formatting_default"
@@ -163,6 +168,7 @@
     </PreferenceScreen>
 
     <PreferenceScreen android:title="@string/settings_mpd"
+        search:ignore="true"
         android:key="pref_category_mpd">
         <Preference
             android:key="mpd_servers_viewer"
@@ -170,6 +176,7 @@
     </PreferenceScreen>
 
     <PreferenceScreen
+        search:ignore="true"
         android:key="pref_category_connectivity"
         android:title="@string/settings_connectivity">
 
@@ -223,6 +230,7 @@
     </PreferenceScreen>
 
     <PreferenceScreen android:title="@string/settings_other"
+        search:ignore="true"
         android:key="pref_category_other">
 
         <Preference

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     android:title="@string/nav_item_settings"
-    android:key="pref_toplevel">
+    android:key="pref_toplevel"
+    xmlns:search="http://schemas.android.com/apk/com.bytehamster.lib.preferencesearch">
+
+    <com.bytehamster.lib.preferencesearch.SearchPreference android:key="searchPreference" />
 
   <PreferenceScreen android:title="@string/settings_appearance"
         android:key="pref_category_ui">
@@ -12,6 +15,7 @@
             android:entryValues="@array/theme_values"
             android:key="theme_name"
             android:title="@string/settings_theme_selection_title"
+            search:summary=""
             android:summary="%s"/>
 
         <CheckBoxPreference
@@ -42,6 +46,7 @@
             android:entryValues="@array/startup_action_entryvalues"
             android:key="startup_action"
             android:summary="@string/startup_action_title_desc"
+            search:summary=""
             android:title="@string/startup_action_title" />
 
         <CheckBoxPreference
@@ -140,6 +145,7 @@
             android:entryValues="@array/timeout_minutes_values"
             android:key="alarm_timeout"
             android:summary="@string/settings_alarm_sleep_timer_desc"
+            search:summary=""
             android:title="@string/settings_alarm_sleep_timer" />
 
     </PreferenceScreen>
@@ -152,6 +158,7 @@
             android:entryValues="@array/settings_record_name_formatting_list"
             android:key="record_name_formatting"
             android:summary="%s"
+            search:summary=""
             android:title="@string/settings_record_name_formatting" />
     </PreferenceScreen>
 
@@ -172,6 +179,7 @@
             android:entryValues="@array/settings_radiobrowser_servers"
             android:key="radiobrowser_server"
             android:summary="%s"
+            search:summary=""
             android:title="@string/settings_radiobrowser_servers" />
 
         <net.programmierecke.radiodroid2.views.IntEditTextPreference
@@ -179,30 +187,35 @@
             android:key="stream_connect_timeout"
             android:maxLength="2"
             android:summary="@string/settings_seconds_format"
+            search:summary=""
             android:title="@string/settings_connect_timeout" />
         <net.programmierecke.radiodroid2.views.IntEditTextPreference
             android:defaultValue="10"
             android:key="stream_read_timeout"
             android:maxLength="2"
             android:summary="@string/settings_seconds_format"
+            search:summary=""
             android:title="@string/settings_read_timeout" />
         <net.programmierecke.radiodroid2.views.IntEditTextPreference
             android:defaultValue="10"
             android:key="settings_retry_timeout"
             android:maxLength="2"
             android:summary="@string/settings_seconds_format"
+            search:summary=""
             android:title="@string/settings_retry_timeout" />
         <net.programmierecke.radiodroid2.views.IntEditTextPreference
             android:defaultValue="0"
             android:key="settings_retry_delay"
             android:maxLength="8"
             android:summary="@string/settings_milliseconds_format"
+            search:summary=""
             android:title="@string/settings_retry_delay" />
         <net.programmierecke.radiodroid2.views.IntEditTextPreference
             android:defaultValue="60"
             android:key="settings_resume_within"
             android:maxLength="3"
             android:summary="@string/settings_seconds_format"
+            search:summary=""
             android:title="@string/settings_resume_timeout" />
         <Preference
             android:key="settings_proxy"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
-    <PreferenceCategory android:title="@string/settings_interface">
+    android:title="@string/nav_item_settings"
+    android:key="pref_toplevel">
+
+  <PreferenceScreen android:title="@string/settings_appearance"
+        android:key="pref_category_ui">
 
         <ListPreference
             android:defaultValue="@string/theme_light"
@@ -13,7 +16,6 @@
 
         <CheckBoxPreference
             android:defaultValue="false"
-            android:dependency="load_icons"
             android:key="circular_icons"
             android:title="@string/settings_circular_icons" />
 
@@ -29,9 +31,10 @@
             android:key="bottom_navigation"
             android:title="@string/settings_bottom_navigation" />
 
-    </PreferenceCategory>
+    </PreferenceScreen>
 
-    <PreferenceCategory android:title="@string/settings_general">
+    <PreferenceScreen android:title="@string/settings_interaction"
+        android:key="pref_category_interaction">
 
         <ListPreference
             android:defaultValue="@string/startup_show_history"
@@ -84,9 +87,10 @@
             android:summaryOn="@string/settings_single_use_tags_desc_on"
             android:title="@string/settings_single_use_tags" />
 
-    </PreferenceCategory>
+    </PreferenceScreen>
 
-    <PreferenceCategory android:title="@string/settings_play">
+    <PreferenceScreen android:title="@string/settings_play"
+        android:key="pref_category_player">
 
         <CheckBoxPreference
             android:defaultValue="false"
@@ -112,9 +116,10 @@
         <Preference
             android:key="equalizer"
             android:title="@string/settings_equalizer" />
-    </PreferenceCategory>
+    </PreferenceScreen>
 
-    <PreferenceCategory android:title="@string/settings_alarm">
+    <PreferenceScreen android:title="@string/settings_alarm"
+        android:key="pref_category_alarm">
 
         <CheckBoxPreference
             android:disableDependentsState="true"
@@ -137,73 +142,29 @@
             android:summary="@string/settings_alarm_sleep_timer_desc"
             android:title="@string/settings_alarm_sleep_timer" />
 
-    </PreferenceCategory>
+    </PreferenceScreen>
 
-    <PreferenceCategory android:title="@string/settings_recordings">
+    <PreferenceScreen android:title="@string/settings_recordings"
+        android:key="pref_category_recordings">
         <ListPreference
             android:defaultValue="@string/settings_record_name_formatting_default"
-            android:dependency="play_external"
             android:entries="@array/settings_record_name_formatting_list_display"
             android:entryValues="@array/settings_record_name_formatting_list"
             android:key="record_name_formatting"
             android:summary="%s"
             android:title="@string/settings_record_name_formatting" />
-    </PreferenceCategory>
+    </PreferenceScreen>
 
-    <PreferenceCategory android:title="@string/settings_mpd">
+    <PreferenceScreen android:title="@string/settings_mpd"
+        android:key="pref_category_mpd">
         <Preference
             android:key="mpd_servers_viewer"
             android:title="@string/settings_view_mpd_servers" />
-    </PreferenceCategory>
+    </PreferenceScreen>
 
-    <PreferenceCategory
+    <PreferenceScreen
         android:key="pref_category_connectivity"
         android:title="@string/settings_connectivity">
-        <net.programmierecke.radiodroid2.views.IntEditTextPreference
-            android:defaultValue="5"
-            android:dependency="play_external"
-            android:key="stream_connect_timeout"
-            android:maxLength="2"
-            android:summary="@string/settings_seconds_format"
-            android:title="@string/settings_connect_timeout" />
-        <net.programmierecke.radiodroid2.views.IntEditTextPreference
-            android:defaultValue="10"
-            android:dependency="play_external"
-            android:key="stream_read_timeout"
-            android:maxLength="2"
-            android:summary="@string/settings_seconds_format"
-            android:title="@string/settings_read_timeout" />
-        <net.programmierecke.radiodroid2.views.IntEditTextPreference
-            android:defaultValue="10"
-            android:dependency="play_external"
-            android:key="settings_retry_timeout"
-            android:maxLength="2"
-            android:summary="@string/settings_seconds_format"
-            android:title="@string/settings_retry_timeout" />
-        <net.programmierecke.radiodroid2.views.IntEditTextPreference
-            android:defaultValue="0"
-            android:dependency="play_external"
-            android:key="settings_retry_delay"
-            android:maxLength="8"
-            android:summary="@string/settings_milliseconds_format"
-            android:title="@string/settings_retry_delay" />
-        <net.programmierecke.radiodroid2.views.IntEditTextPreference
-            android:defaultValue="60"
-            android:dependency="play_external"
-            android:key="settings_resume_within"
-            android:maxLength="3"
-            android:summary="@string/settings_seconds_format"
-            android:title="@string/settings_resume_timeout" />
-        <Preference
-            android:key="settings_proxy"
-            android:title="@string/settings_proxy" />
-    </PreferenceCategory>
-
-    <PreferenceCategory android:title="@string/settings_other">
-
-        <Preference
-            android:key="show_statistics"
-            android:title="@string/settings_statistics" />
 
         <ListPreference
             android:defaultValue="@string/settings_radiobrowser_servers_default"
@@ -213,9 +174,51 @@
             android:summary="%s"
             android:title="@string/settings_radiobrowser_servers" />
 
+        <net.programmierecke.radiodroid2.views.IntEditTextPreference
+            android:defaultValue="5"
+            android:key="stream_connect_timeout"
+            android:maxLength="2"
+            android:summary="@string/settings_seconds_format"
+            android:title="@string/settings_connect_timeout" />
+        <net.programmierecke.radiodroid2.views.IntEditTextPreference
+            android:defaultValue="10"
+            android:key="stream_read_timeout"
+            android:maxLength="2"
+            android:summary="@string/settings_seconds_format"
+            android:title="@string/settings_read_timeout" />
+        <net.programmierecke.radiodroid2.views.IntEditTextPreference
+            android:defaultValue="10"
+            android:key="settings_retry_timeout"
+            android:maxLength="2"
+            android:summary="@string/settings_seconds_format"
+            android:title="@string/settings_retry_timeout" />
+        <net.programmierecke.radiodroid2.views.IntEditTextPreference
+            android:defaultValue="0"
+            android:key="settings_retry_delay"
+            android:maxLength="8"
+            android:summary="@string/settings_milliseconds_format"
+            android:title="@string/settings_retry_delay" />
+        <net.programmierecke.radiodroid2.views.IntEditTextPreference
+            android:defaultValue="60"
+            android:key="settings_resume_within"
+            android:maxLength="3"
+            android:summary="@string/settings_seconds_format"
+            android:title="@string/settings_resume_timeout" />
+        <Preference
+            android:key="settings_proxy"
+            android:title="@string/settings_proxy" />
+    </PreferenceScreen>
+
+    <PreferenceScreen android:title="@string/settings_other"
+        android:key="pref_category_other">
+
+        <Preference
+            android:key="show_statistics"
+            android:title="@string/settings_statistics" />
+
         <Preference
             android:key="show_about"
             android:title="@string/settings_about" />
 
-    </PreferenceCategory>
+    </PreferenceScreen>
 </PreferenceScreen>

--- a/build.gradle
+++ b/build.gradle
@@ -13,5 +13,6 @@ allprojects {
     repositories {
         jcenter()
         google()
+        maven { url 'https://jitpack.io' }
     }
 }


### PR DESCRIPTION
Fixes #507

Everything seems to work now, including search and back logic.

In a second PR we could re-organize a bit more, maybe.:

* add new sub-screen startup-up, including start-action and auto-play on start
* move MPD to connectivity
* move off-wifi-warning to connectivity

<img width="320" src="https://user-images.githubusercontent.com/1309388/59158530-b283a480-8abb-11e9-9304-67a6071a5061.png"> <img width="320" src="https://user-images.githubusercontent.com/1309388/59158531-b283a480-8abb-11e9-8caf-1efc1377da84.png">
<img width="320" src="https://user-images.githubusercontent.com/1309388/59158533-b31c3b00-8abb-11e9-8c60-e8b1ea7e8ad0.png"> <img width="320" src="https://user-images.githubusercontent.com/1309388/59158534-b31c3b00-8abb-11e9-94e2-e4085f60bac5.png">
<img width="320" src="https://user-images.githubusercontent.com/1309388/59158535-b31c3b00-8abb-11e9-89a2-4c3fe280360e.png"> <img width="320" src="https://user-images.githubusercontent.com/1309388/59158536-b31c3b00-8abb-11e9-8d43-e634ea0c7ad9.png">
<img width="320" src="https://user-images.githubusercontent.com/1309388/59158537-b31c3b00-8abb-11e9-90d5-baf949eea7ff.png"> <img width="320" src="https://user-images.githubusercontent.com/1309388/59158538-b3b4d180-8abb-11e9-848d-1b123331ce09.png">
<img width="320" src="https://user-images.githubusercontent.com/1309388/59158539-b3b4d180-8abb-11e9-9db3-3dc61cb722f9.png">



