### PR TITLE
Respect warn_no_wifi setting when resuming after connection regain

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/ExoPlayerWrapper.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/ExoPlayerWrapper.java
@@ -85,8 +85,10 @@ public class ExoPlayerWrapper implements PlayerWrapper, IcyDataSource.IcyDataSou
     private final BroadcastReceiver networkChangedReceiver = new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {
+            SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(context);
+            final boolean warn_no_wifi = sharedPref.getBoolean("warn_no_wifi", false);
             if (interruptedByConnectionLoss && player != null && audioSource != null
-                    && Utils.hasAnyConnection(context)) {
+                    && (Utils.hasWifiConnection(context) || (!warn_no_wifi && Utils.hasAnyConnection(context)))) {
                 interruptedByConnectionLoss = false;
                 Log.i(TAG, "Regained connection. Resuming playback.");
                 player.prepare(audioSource);


### PR DESCRIPTION
Fixes #475 - at least to the extent that the behavior is the same as in the last stable release v0.69.