### PR TITLE
Fix attempt to auto start playback before PlayerService is bound

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/service/PlayerService.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/service/PlayerService.java
@@ -76,6 +76,8 @@ public class PlayerService extends Service implements RadioPlayer.PlayerListener
     public static final String PLAYER_SERVICE_STATE_CHANGE = "net.programmierecke.radiodroid2.statechange";
     public static final String PLAYER_SERVICE_STATE_EXTRA_KEY = "state";
 
+    public static final String PLAYER_SERVICE_BOUND = "net.programmierecke.radiodroid2.playerservicebound";
+
     private final String TAG = "PLAY";
 
     private final String ACTION_PAUSE = "pause";

--- a/app/src/main/java/net/programmierecke/radiodroid2/service/PlayerServiceUtil.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/service/PlayerServiceUtil.java
@@ -14,6 +14,7 @@ import android.widget.ImageView;
 
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.squareup.picasso.Callback;
 import com.squareup.picasso.NetworkPolicy;
@@ -81,6 +82,10 @@ public class PlayerServiceUtil {
                     Log.d("PLAYER", "Service came online");
                 }
                 itsPlayerService = IPlayerService.Stub.asInterface(binder);
+
+                Intent local = new Intent();
+                local.setAction(PlayerService.PLAYER_SERVICE_BOUND);
+                LocalBroadcastManager.getInstance(mainContext).sendBroadcast(local);
             }
 
             public void onServiceDisconnected(ComponentName className) {
@@ -90,6 +95,10 @@ public class PlayerServiceUtil {
                 unBind(mainContext);
             }
         };
+    }
+
+    public static boolean isServiceBound() {
+        return itsPlayerService != null;
     }
 
     public static boolean isPlaying() {


### PR DESCRIPTION
Playback was attempted before PlayerService's binding completion.
Now we also try to start playback on PlayerService bound event.

Closes: #593
Fixes: 05279ce