### PR TITLE
Use alarmMgr.setAlarmClock API for system to show upcoming alarms

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/alarm/RadioAlarmManager.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/alarm/RadioAlarmManager.java
@@ -224,10 +224,7 @@ public class RadioAlarmManager {
                     + " " + calendar.get(Calendar.HOUR_OF_DAY) + ":" + calendar.get(Calendar.MINUTE)
             );
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                if(BuildConfig.DEBUG) { Log.d("ALARM","START setExactAndAllowWhileIdle"); }
-                alarmMgr.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP,calendar.getTimeInMillis(),alarmIntent);
-            }else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 if(BuildConfig.DEBUG) { Log.d("ALARM","START setAlarmClock"); }
                 alarmMgr.setAlarmClock(new AlarmManager.AlarmClockInfo(calendar.getTimeInMillis(),alarmIntent),alarmIntent);
             }else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {


### PR DESCRIPTION
Currently the [`setExactAndAllowWhileIdle()`](https://developer.android.com/reference/android/app/AlarmManager.html#setExactAndAllowWhileIdle(int,%20long,%20android.app.PendingIntent)) method is used to set alarm times. However, this does not show that there is an upcoming alarm in the system UI.

[`setAlarmClock()`](https://developer.android.com/reference/android/app/AlarmManager.html#setAlarmClock(android.app.AlarmManager.AlarmClockInfo,%20android.app.PendingIntent)) is the same as `setExactAndAllowWhileIdle()` with the added extra of showing that there is an upcoming alarm set. Upcoming alarms are shown in the status bar and on the lock screen.

![2040128112](https://user-images.githubusercontent.com/144435/68087384-31072700-fe4d-11e9-8ad8-388cad541243.png)
