### PR TITLE
Alarm clock play system alarm if radio station fails to load

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/alarm/AlarmReceiver.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/alarm/AlarmReceiver.java
@@ -218,7 +218,6 @@ public class AlarmReceiver extends BroadcastReceiver {
     private void PlaySystemAlarm(Context context) {
         if(BuildConfig.DEBUG) { Log.d(TAG, "Starting system alarm"); }
 
-        //Define sound URI
         Uri soundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM);
 
         // Create the NotificationChannel, but only on API 26+ because
@@ -242,7 +241,6 @@ public class AlarmReceiver extends BroadcastReceiver {
             notificationManager.createNotificationChannel(channel);
         }
 
-        //Define Notification Manager
         NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 
         NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(context, BACKUP_NOTIFICATION_NAME)
@@ -253,7 +251,6 @@ public class AlarmReceiver extends BroadcastReceiver {
                 .setSound(soundUri)
                 .setAutoCancel(true);
 
-        //Display notification
         notificationManager.notify(BACKUP_NOTIFICATION_ID, mBuilder.build());
     }
 }

--- a/app/src/main/java/net/programmierecke/radiodroid2/alarm/AlarmReceiver.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/alarm/AlarmReceiver.java
@@ -1,11 +1,16 @@
 package net.programmierecke.radiodroid2.alarm;
 
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
 import android.content.SharedPreferences;
+import android.media.AudioAttributes;
+import android.media.RingtoneManager;
 import android.net.Uri;
 import android.net.wifi.WifiManager;
 import android.os.AsyncTask;
@@ -16,6 +21,7 @@ import android.os.RemoteException;
 import android.util.Log;
 import android.widget.Toast;
 
+import androidx.core.app.NotificationCompat;
 import androidx.preference.PreferenceManager;
 
 import net.programmierecke.radiodroid2.BuildConfig;
@@ -36,6 +42,8 @@ public class AlarmReceiver extends BroadcastReceiver {
     PowerManager.WakeLock wakeLock;
     private WifiManager.WifiLock wifiLock;
     private final String TAG = "RECV";
+    static int BACKUP_NOTIFICATION_ID = 2;
+    static String BACKUP_NOTIFICATION_NAME = "backup-alarm";
 
     @Override
     public void onReceive(Context context, Intent intent) {
@@ -164,28 +172,35 @@ public class AlarmReceiver extends BroadcastReceiver {
                     }catch(Exception e){
                         timeout = 10;
                     }
-                    if (play_external && packageName != null && activityName != null){
-                        Intent share = new Intent(Intent.ACTION_VIEW);
-                        share.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                        share.setClassName(packageName,activityName);
-                        share.setDataAndType(Uri.parse(url), "audio/*");
-                        context.startActivity(share);
-                        if (wakeLock != null) {
-                            wakeLock.release();
-                            wakeLock = null;
+                    try {
+                        if (play_external && packageName != null && activityName != null){
+                            Intent share = new Intent(Intent.ACTION_VIEW);
+                            share.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                            share.setClassName(packageName,activityName);
+                            share.setDataAndType(Uri.parse(url), "audio/*");
+                            context.startActivity(share);
+                            if (wakeLock != null) {
+                                wakeLock.release();
+                                wakeLock = null;
+                            }
+                            if (wifiLock != null) {
+                                wifiLock.release();
+                                wifiLock = null;
+                            }
+                        } else {
+                            Intent anIntent = new Intent(context, PlayerService.class);
+                            context.getApplicationContext().bindService(anIntent, svcConn, context.BIND_AUTO_CREATE);
+                            context.getApplicationContext().startService(anIntent);
                         }
-                        if (wifiLock != null) {
-                            wifiLock.release();
-                            wifiLock = null;
-                        }
-                    }else {
-                        Intent anIntent = new Intent(context, PlayerService.class);
-                        context.getApplicationContext().bindService(anIntent, svcConn, context.BIND_AUTO_CREATE);
-                        context.getApplicationContext().startService(anIntent);
+                    } catch (Exception e) {
+                        Log.e(TAG, "Error starting alarm intent "+e);
+                        PlaySystemAlarm(context);
                     }
                 } else {
+                    Log.e(TAG, "Could not connect to radio station");
                     Toast toast = Toast.makeText(context, context.getResources().getText(R.string.error_station_load), Toast.LENGTH_SHORT);
                     toast.show();
+                    PlaySystemAlarm(context);
                     if (wakeLock != null) {
                         wakeLock.release();
                         wakeLock = null;
@@ -198,5 +213,47 @@ public class AlarmReceiver extends BroadcastReceiver {
                 super.onPostExecute(result);
             }
         }.execute();
+    }
+
+    private void PlaySystemAlarm(Context context) {
+        if(BuildConfig.DEBUG) { Log.d(TAG, "Starting system alarm"); }
+
+        //Define sound URI
+        Uri soundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM);
+
+        // Create the NotificationChannel, but only on API 26+ because
+        // the NotificationChannel class is new and not in the support library
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            CharSequence name = context.getString(R.string.alarm_backup);
+            String description = context.getString(R.string.alarm_back_desc);
+            int importance = NotificationManager.IMPORTANCE_HIGH;
+            NotificationChannel channel = new NotificationChannel(BACKUP_NOTIFICATION_NAME, name, importance);
+            channel.setDescription(description);
+
+            AudioAttributes audioAttributes = new AudioAttributes.Builder()
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                    .setUsage(AudioAttributes.USAGE_ALARM)
+                    .build();
+            channel.setSound(soundUri, audioAttributes);
+
+            // Register the channel with the system; you can't change the importance
+            // or other notification behaviors after this
+            NotificationManager notificationManager = context.getSystemService(NotificationManager.class);
+            notificationManager.createNotificationChannel(channel);
+        }
+
+        //Define Notification Manager
+        NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+
+        NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(context, BACKUP_NOTIFICATION_NAME)
+                .setSmallIcon(R.drawable.ic_access_alarms_black_24dp)
+                .setContentTitle(context.getString(R.string.action_alarm))
+                .setContentText(context.getString(R.string.alarm_fallback_info))
+                .setDefaults(Notification.DEFAULT_SOUND)
+                .setSound(soundUri)
+                .setAutoCancel(true);
+
+        //Display notification
+        notificationManager.notify(BACKUP_NOTIFICATION_ID, mBuilder.build());
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -295,4 +295,8 @@
     <string name="nav_item_statistics">Statistics</string>
     <string name="nav_item_about">About</string>
     <string name="refresh">Refresh</string>
+
+    <string name="alarm_backup">Backup Alarm</string>
+    <string name="alarm_fallback_info">Using system alarm as selected radio station failed to load</string>
+    <string name="alarm_back_desc">Backup system alarm for when the radio station fails to load</string>
 </resources>


### PR DESCRIPTION
Partly fixes https://github.com/segler-alex/RadioDroid/issues/393

If the user has no internet connection when the alarm goes off, currently the alarm will fail silently.

This PR will fallback to the default system alarm sound if the radio station fails to load.