### PR TITLE
Fix long text being truncated in BottomNavigationView

### DIFF
--- a/app/src/main/res/layout/layout_main.xml
+++ b/app/src/main/res/layout/layout_main.xml
@@ -131,6 +131,7 @@
         android:layout_height="wrap_content"
         android:background="?attr/menuBottomBackgroundColor"
         app:itemBackground="?attr/selectableItemBackgroundBorderless"
+        app:itemHorizontalTranslationEnabled="true"
         app:itemIconTint="@color/menu_bottom_text_color"
         app:itemTextColor="@color/menu_bottom_text_color"
         app:menu="@menu/menu_bottom_navigation" />


### PR DESCRIPTION
It was a regression introduced when I updated the libraries in 8ccb828.

Now it needs to be explicitly specified that selected item should push
other aside in BottomNavigationView.

In some cases it still may not be enough to fit the text but it doesn't
happen at the moment so nothing more is needed to be done. Otherwise
it will be necessary to make the TextViews to auto resize the text.

Closes: #607
Fixes: 8ccb828

@Wikinaut Could you check it?