### PR TITLE
Fix rare crash when responseBody is null in IcyDataSource.readInternal

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/IcyDataSource.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/IcyDataSource.java
@@ -239,6 +239,10 @@ public class IcyDataSource implements HttpDataSource {
     }
 
     private int readInternal(byte[] buffer, int offset, int readLength) throws HttpDataSourceException {
+        if (responseBody == null) {
+            throw new HttpDataSourceException(dataSpec, HttpDataSourceException.TYPE_READ);
+        }
+
         InputStream stream = responseBody.byteStream();
 
         int ret = 0;


### PR DESCRIPTION
Happened to me once, better be safe.