### PR TITLE
Fix crash on Android 4.X by downgrading OkHttp

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,8 +88,11 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
 
+    // Keep OkHttp 3.12.X to support Android 4.X, see https://developer.squareup.com/blog/okhttp-3-13-requires-android-5
+    //noinspection GradleDependency
+    implementation 'com.squareup.okhttp3:okhttp:3.12.6'
+
     implementation 'com.google.code.gson:gson:2.8.5'
-    implementation 'com.squareup.okhttp3:okhttp:4.2.1'
     implementation 'com.squareup.picasso:picasso:2.71828'
     implementation 'jp.wasabeef:picasso-transformations:2.2.1'
     implementation 'com.google.android.exoplayer:exoplayer-core:2.9.6'


### PR DESCRIPTION
The latest OkHttps versions which support Android 4.X are 3.12.*

See https://developer.squareup.com/blog/okhttp-3-13-requires-android-5

Reported in #642

Fixes: 0afe8b8509eb7792d14e5aede08b209873144d85