### PR TITLE
Fix metered connection warning. Refactor server selection dialog.

### DIFF
--- a/app/src/main/aidl/net/programmierecke/radiodroid2/IPlayerService.aidl
+++ b/app/src/main/aidl/net/programmierecke/radiodroid2/IPlayerService.aidl
@@ -5,6 +5,7 @@ import net.programmierecke.radiodroid2.station.DataRadioStation;
 import net.programmierecke.radiodroid2.station.live.StreamLiveInfo;
 import net.programmierecke.radiodroid2.station.live.ShoutcastInfo;
 import net.programmierecke.radiodroid2.players.PlayState;
+import net.programmierecke.radiodroid2.players.selector.PlayerType;
 import android.support.v4.media.session.MediaSessionCompat;
 
 interface IPlayerService
@@ -39,5 +40,5 @@ PauseReason getPauseReason();
 void enableMPD(String hostname, int port);
 void disableMPD();
 
-void warnAboutMeteredConnection();
+void warnAboutMeteredConnection(in PlayerType playerType);
 }

--- a/app/src/main/aidl/net/programmierecke/radiodroid2/IPlayerService.aidl
+++ b/app/src/main/aidl/net/programmierecke/radiodroid2/IPlayerService.aidl
@@ -38,4 +38,6 @@ PauseReason getPauseReason();
 
 void enableMPD(String hostname, int port);
 void disableMPD();
+
+void warnAboutMeteredConnection();
 }

--- a/app/src/main/aidl/net/programmierecke/radiodroid2/players/selector/PlayerType.aidl
+++ b/app/src/main/aidl/net/programmierecke/radiodroid2/players/selector/PlayerType.aidl
@@ -1,0 +1,3 @@
+package net.programmierecke.radiodroid2.players.selector;
+
+parcelable PlayerType;

--- a/app/src/main/java/net/programmierecke/radiodroid2/ActivityMain.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/ActivityMain.java
@@ -62,6 +62,8 @@ import net.programmierecke.radiodroid2.interfaces.IFragmentSearchable;
 import net.programmierecke.radiodroid2.players.PlayState;
 import net.programmierecke.radiodroid2.players.mpd.MPDServerData;
 import net.programmierecke.radiodroid2.players.mpd.MPDServersRepository;
+import net.programmierecke.radiodroid2.players.selector.PlayStationTask;
+import net.programmierecke.radiodroid2.players.selector.PlayerType;
 import net.programmierecke.radiodroid2.service.MediaSessionCallback;
 import net.programmierecke.radiodroid2.service.PlayerService;
 import net.programmierecke.radiodroid2.service.PlayerServiceUtil;
@@ -134,6 +136,8 @@ public class ActivityMain extends AppCompatActivity implements SearchView.OnQuer
     private boolean instanceStateWasSaved;
 
     private Date lastExitTry;
+
+    private AlertDialog meteredConnectionAlertDialog;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -594,7 +598,7 @@ public class ActivityMain extends AppCompatActivity implements SearchView.OnQuer
         menuItemListView.setVisible(false);
         menuItemIconsView.setVisible(false);
         menuItemAddAlarm.setVisible(false);
-        
+
         MPDServersRepository mpdServersRepository = new MPDServersRepository(getApplicationContext());
         LiveData<List<MPDServerData>> mpdServers = mpdServersRepository.getAllServers();
         menuItemMpd.setVisible(mpdServers.getValue().size() > 0);
@@ -683,7 +687,7 @@ public class ActivityMain extends AppCompatActivity implements SearchView.OnQuer
         }
     }
 
-    void SaveFavourites(){
+    void SaveFavourites() {
         SaveFileDialog dialog = new SaveFileDialog();
         dialog.setStyle(DialogFragment.STYLE_NO_TITLE, Utils.getThemeResId(this));
         Bundle args = new Bundle();
@@ -692,7 +696,7 @@ public class ActivityMain extends AppCompatActivity implements SearchView.OnQuer
         dialog.show(getSupportFragmentManager(), SaveFileDialog.class.getName());
     }
 
-    void LoadFavourites(){
+    void LoadFavourites() {
         OpenFileDialog dialogOpen = new OpenFileDialog();
         dialogOpen.setStyle(DialogFragment.STYLE_NO_TITLE, Utils.getThemeResId(this));
         Bundle argsOpen = new Bundle();
@@ -867,7 +871,7 @@ public class ActivityMain extends AppCompatActivity implements SearchView.OnQuer
     }
 
     public void Search(StationsFilter.SearchStyle searchStyle, String query) {
-        Log.d("MAIN","Search() searchstyle=" + searchStyle + " query=" + query);
+        Log.d("MAIN", "Search() searchstyle=" + searchStyle + " query=" + query);
         Fragment currentFragment = mFragmentManager.getFragments().get(mFragmentManager.getFragments().size() - 1);
         if (currentFragment instanceof FragmentTabs) {
             ((FragmentTabs) currentFragment).Search(searchStyle, query);
@@ -932,10 +936,26 @@ public class ActivityMain extends AppCompatActivity implements SearchView.OnQuer
         return true;
     }
 
+    private void showMeteredConnectionDialog(@NonNull Runnable playFunc) {
+        Resources res = this.getResources();
+        String title = res.getString(R.string.alert_metered_connection_title);
+        String text = res.getString(R.string.alert_metered_connection_message);
+        meteredConnectionAlertDialog = new AlertDialog.Builder(this)
+                .setTitle(title)
+                .setMessage(text)
+                .setNegativeButton(android.R.string.cancel, null)
+                .setPositiveButton(android.R.string.ok, (dialog, which) -> playFunc.run())
+                .setOnDismissListener(dialog -> meteredConnectionAlertDialog = null)
+                .create();
+
+        meteredConnectionAlertDialog.show();
+    }
+
     private void setupBroadcastReceiver() {
         IntentFilter filter = new IntentFilter();
         filter.addAction(ACTION_HIDE_LOADING);
         filter.addAction(ACTION_SHOW_LOADING);
+        filter.addAction(PlayerService.PLAYER_SERVICE_STATE_CHANGE);
         filter.addAction(PlayerService.PLAYER_SERVICE_METERED_CONNECTION);
         broadcastReceiver = new BroadcastReceiver() {
             @Override
@@ -945,8 +965,33 @@ public class ActivityMain extends AppCompatActivity implements SearchView.OnQuer
                 } else if (intent.getAction().equals(ACTION_SHOW_LOADING)) {
                     showLoadingIcon();
                 } else if (intent.getAction().equals(PlayerService.PLAYER_SERVICE_METERED_CONNECTION)) {
-                    Utils.showMeteredConnectionDialog(ActivityMain.this,
-                            () -> Utils.play((RadioDroidApp) getApplication(), PlayerServiceUtil.getCurrentStation()));
+                    if (meteredConnectionAlertDialog != null) {
+                        meteredConnectionAlertDialog.cancel();
+                        meteredConnectionAlertDialog = null;
+                    }
+
+                    PlayerType playerType = intent.getParcelableExtra(PlayerService.PLAYER_SERVICE_METERED_CONNECTION_PLAYER_TYPE);
+
+                    switch (playerType) {
+                        case RADIODROID:
+                            showMeteredConnectionDialog(() -> Utils.play((RadioDroidApp) getApplication(), PlayerServiceUtil.getCurrentStation()));
+                            break;
+                        case EXTERNAL:
+                            DataRadioStation currentStation = PlayerServiceUtil.getCurrentStation();
+                            if (currentStation != null) {
+                                showMeteredConnectionDialog(() -> PlayStationTask.playExternal(currentStation, ActivityMain.this).execute());
+                            }
+                            break;
+                        default:
+                            Log.e(TAG, String.format("broadcastReceiver unexpected PlayerType '%s'", playerType.toString()));
+                    }
+                } else if (intent.getAction().equals(PlayerService.PLAYER_SERVICE_STATE_CHANGE)) {
+                    if (PlayerServiceUtil.isPlaying()) {
+                        if (meteredConnectionAlertDialog != null) {
+                            meteredConnectionAlertDialog.cancel();
+                            meteredConnectionAlertDialog = null;
+                        }
+                    }
                 }
             }
         };

--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentBase.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentBase.java
@@ -100,7 +100,7 @@ public class FragmentBase extends Fragment {
             String cache = Utils.getCacheFile(getActivity(), relativeUrl);
             if (cache == null || forceUpdate) {
                 if (getContext() != null && displayProgress) {
-                    getContext().sendBroadcast(new Intent(ActivityMain.ACTION_SHOW_LOADING));
+                    LocalBroadcastManager.getInstance(getContext()).sendBroadcast(new Intent(ActivityMain.ACTION_SHOW_LOADING));
                 }
 
                 RadioDroidApp radioDroidApp = (RadioDroidApp) getActivity().getApplication();

--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentServerInfo.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentServerInfo.java
@@ -41,7 +41,7 @@ public class FragmentServerInfo extends Fragment implements IFragmentRefreshable
     }
 
     void Download(final boolean forceUpdate){
-        getContext().sendBroadcast(new Intent(ActivityMain.ACTION_SHOW_LOADING));
+        LocalBroadcastManager.getInstance(getContext()).sendBroadcast(new Intent(ActivityMain.ACTION_SHOW_LOADING));
 
         RadioDroidApp radioDroidApp = (RadioDroidApp) getActivity().getApplication();
         final OkHttpClient httpClient = radioDroidApp.getHttpClient();

--- a/app/src/main/java/net/programmierecke/radiodroid2/StationSaveManager.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/StationSaveManager.java
@@ -197,7 +197,7 @@ public class StationSaveManager extends Observable {
     private void refreshStationsFromServer() {
         final RadioDroidApp radioDroidApp = (RadioDroidApp) context.getApplicationContext();
         final OkHttpClient httpClient = radioDroidApp.getHttpClient();
-        context.sendBroadcast(new Intent(ActivityMain.ACTION_SHOW_LOADING));
+        LocalBroadcastManager.getInstance(context).sendBroadcast(new Intent(ActivityMain.ACTION_SHOW_LOADING));
 
         new AsyncTask<Void, Void, Integer>() {
             @Override

--- a/app/src/main/java/net/programmierecke/radiodroid2/Utils.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/Utils.java
@@ -304,17 +304,10 @@ public class Utils {
         final boolean warnOnMetered = sharedPref.getBoolean("warn_no_wifi", false);
 
         if (warnOnMetered && ConnectivityChecker.getCurrentConnectionType(radioDroidApp) == ConnectivityChecker.ConnectionType.METERED) {
-            ToneGenerator toneG = new ToneGenerator(AudioManager.STREAM_ALARM, 100);
-            toneG.startTone(ToneGenerator.TONE_SUP_RADIO_NOTAVAIL, 2000);
-
-            Intent local = new Intent();
-            local.setAction(PlayerService.PLAYER_SERVICE_METERED_CONNECTION);
-            LocalBroadcastManager.getInstance(radioDroidApp).sendBroadcast(local);
-
             // Making sure that resuming from notification or some external event will actually resume
             // and not issue warning a second time.
             PlayerServiceUtil.setStation(station);
-            PlayerServiceUtil.pause(PauseReason.METERED_CONNECTION);
+            PlayerServiceUtil.warnAboutMeteredConnection();
         } else {
             play(radioDroidApp, station);
         }

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/RadioPlayer.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/RadioPlayer.java
@@ -141,6 +141,10 @@ public class RadioPlayer implements PlayerWrapper.PlayListener, Recordable {
         cancelStationLinkRetrieval();
 
         playerThreadHandler.post(() -> {
+            if (playState == PlayState.Idle || playState == PlayState.Paused) {
+                return;
+            }
+
             final int audioSessionId = getAudioSessionId();
             currentPlayer.pause();
 
@@ -252,6 +256,10 @@ public class RadioPlayer implements PlayerWrapper.PlayListener, Recordable {
 
     private void setState(PlayState state, int audioSessionId) {
         if (BuildConfig.DEBUG) Log.d(TAG, String.format("set state '%s'", state.name()));
+
+        if (playState == state) {
+            return;
+        }
 
         if (BuildConfig.DEBUG) {
             if (state == PlayState.Playing) {

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/RadioPlayer.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/RadioPlayer.java
@@ -323,7 +323,7 @@ public class RadioPlayer implements PlayerWrapper.PlayListener, Recordable {
 
         @Override
         protected void onPreExecute() {
-            radioPlayer.mainContext.sendBroadcast(new Intent(ActivityMain.ACTION_SHOW_LOADING));
+            LocalBroadcastManager.getInstance(radioPlayer.mainContext).sendBroadcast(new Intent(ActivityMain.ACTION_SHOW_LOADING));
 
             super.onPreExecute();
         }

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/mpd/MPDServerData.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/mpd/MPDServerData.java
@@ -6,7 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class MPDServerData {
-    enum Status {
+    public enum Status {
         Idle,
         Paused,
         Playing,

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/mpd/MPDServersAdapter.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/mpd/MPDServersAdapter.java
@@ -125,7 +125,7 @@ public class MPDServersAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
             Context ctx = contextWeakReference.get();
             if (ctx != null) {
-                ctx.sendBroadcast(new Intent(ActivityMain.ACTION_SHOW_LOADING));
+                LocalBroadcastManager.getInstance(ctx).sendBroadcast(new Intent(ActivityMain.ACTION_SHOW_LOADING));
             }
         }
 

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/selector/PlayStationTask.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/selector/PlayStationTask.java
@@ -1,0 +1,96 @@
+package net.programmierecke.radiodroid2.players.selector;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.AsyncTask;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+
+import net.programmierecke.radiodroid2.ActivityMain;
+import net.programmierecke.radiodroid2.CastHandler;
+import net.programmierecke.radiodroid2.R;
+import net.programmierecke.radiodroid2.RadioDroidApp;
+import net.programmierecke.radiodroid2.Utils;
+import net.programmierecke.radiodroid2.players.mpd.MPDClient;
+import net.programmierecke.radiodroid2.players.mpd.MPDServerData;
+import net.programmierecke.radiodroid2.players.mpd.tasks.MPDPlayTask;
+import net.programmierecke.radiodroid2.station.DataRadioStation;
+
+import java.lang.ref.WeakReference;
+
+public class PlayStationTask extends AsyncTask<Void, Void, String> {
+    private interface PlayFunc {
+        void play(String url);
+    }
+
+    private PlayFunc playFunc;
+    private DataRadioStation stationToPlay;
+    private WeakReference<Context> contextWeakReference;
+
+    private PlayStationTask(@NonNull DataRadioStation stationToPlay, @NonNull Context ctx, PlayFunc playFunc) {
+        this.stationToPlay = stationToPlay;
+        this.contextWeakReference = new WeakReference<>(ctx);
+        this.playFunc = playFunc;
+    }
+
+    public static PlayStationTask playMPD(MPDClient mpdClient, MPDServerData mpdServerData, DataRadioStation stationToPlay, Context ctx) {
+        return new PlayStationTask(stationToPlay, ctx, url -> mpdClient.enqueueTask(mpdServerData, new MPDPlayTask(url, null)));
+    }
+
+    public static PlayStationTask playExternal(DataRadioStation stationToPlay, Context ctx) {
+        return new PlayStationTask(stationToPlay, ctx, url -> {
+            Intent share = new Intent(Intent.ACTION_VIEW);
+            share.setDataAndType(Uri.parse(url), "audio/*");
+            ctx.startActivity(share);
+        });
+    }
+
+    public static PlayStationTask playCAST(DataRadioStation stationToPlay, Context ctx) {
+        return new PlayStationTask(stationToPlay, ctx, url -> CastHandler.PlayRemote(stationToPlay.Name, url, stationToPlay.IconUrl));
+    }
+
+    @Override
+    protected void onPreExecute() {
+        super.onPreExecute();
+
+        Context ctx = contextWeakReference.get();
+        if (ctx != null) {
+            LocalBroadcastManager.getInstance(ctx).sendBroadcast(new Intent(ActivityMain.ACTION_SHOW_LOADING));
+        }
+    }
+
+    @Override
+    protected String doInBackground(Void... params) {
+        Context ctx = contextWeakReference.get();
+        if (ctx != null) {
+            RadioDroidApp radioDroidApp = (RadioDroidApp) ctx.getApplicationContext();
+            return Utils.getRealStationLink(radioDroidApp.getHttpClient(), ctx.getApplicationContext(), stationToPlay.StationUuid);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    protected void onPostExecute(String result) {
+        Context ctx = contextWeakReference.get();
+        if (ctx == null) {
+            return;
+        }
+
+        LocalBroadcastManager.getInstance(ctx).sendBroadcast(new Intent(ActivityMain.ACTION_HIDE_LOADING));
+
+        if (result != null) {
+            stationToPlay.playableUrl = result;
+            playFunc.play(result);
+        } else {
+            Toast toast = Toast.makeText(ctx.getApplicationContext(),
+                    ctx.getResources()
+                            .getText(R.string.error_station_load), Toast.LENGTH_SHORT);
+            toast.show();
+        }
+        super.onPostExecute(result);
+    }
+}

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/selector/PlayerSelectorDialog.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/selector/PlayerSelectorDialog.java
@@ -1,4 +1,4 @@
-package net.programmierecke.radiodroid2.players.mpd;
+package net.programmierecke.radiodroid2.players.selector;
 
 
 import android.content.BroadcastReceiver;
@@ -25,6 +25,9 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 
 import net.programmierecke.radiodroid2.R;
 import net.programmierecke.radiodroid2.RadioDroidApp;
+import net.programmierecke.radiodroid2.players.mpd.MPDClient;
+import net.programmierecke.radiodroid2.players.mpd.MPDServerData;
+import net.programmierecke.radiodroid2.players.mpd.MPDServersRepository;
 import net.programmierecke.radiodroid2.service.PlayerService;
 import net.programmierecke.radiodroid2.station.DataRadioStation;
 
@@ -32,7 +35,7 @@ import java.util.List;
 
 import static net.programmierecke.radiodroid2.Utils.parseIntWithDefault;
 
-public class MPDServersDialog extends BottomSheetDialogFragment {
+public class PlayerSelectorDialog extends BottomSheetDialogFragment {
 
     public static final String FRAGMENT_TAG = "mpd_servers_dialog_fragment";
 
@@ -42,18 +45,18 @@ public class MPDServersDialog extends BottomSheetDialogFragment {
     private BroadcastReceiver updateUIReceiver;
 
     private RecyclerView recyclerViewServers;
-    private MPDServersAdapter mpdServersAdapter;
+    private PlayerSelectorAdapter playerSelectorAdapter;
 
     private MPDServersRepository serversRepository;
 
     private Button btnEnableMPD;
     private Button btnAddMPDServer;
 
-    public MPDServersDialog(@NonNull MPDClient mpdClient) {
+    public PlayerSelectorDialog(@NonNull MPDClient mpdClient) {
         this.mpdClient = mpdClient;
     }
 
-    public MPDServersDialog(@NonNull MPDClient mpdClient, @NonNull DataRadioStation stationToPlay) {
+    public PlayerSelectorDialog(@NonNull MPDClient mpdClient, @NonNull DataRadioStation stationToPlay) {
         this.mpdClient = mpdClient;
         this.stationToPlay = stationToPlay;
     }
@@ -72,8 +75,8 @@ public class MPDServersDialog extends BottomSheetDialogFragment {
         GridLayoutManager llm = new GridLayoutManager(getContext(), 2, RecyclerView.VERTICAL, false);
         recyclerViewServers.setLayoutManager(llm);
 
-        mpdServersAdapter = new MPDServersAdapter(requireContext(), stationToPlay);
-        mpdServersAdapter.setActionListener(new MPDServersAdapter.ActionListener() {
+        playerSelectorAdapter = new PlayerSelectorAdapter(requireContext(), stationToPlay);
+        playerSelectorAdapter.setActionListener(new PlayerSelectorAdapter.ActionListener() {
             @Override
             public void editServer(@NonNull MPDServerData mpdServerData) {
                 editOrAddServer(new MPDServerData(mpdServerData));
@@ -84,7 +87,7 @@ public class MPDServersDialog extends BottomSheetDialogFragment {
                 serversRepository.removeServer(mpdServerData);
             }
         });
-        recyclerViewServers.setAdapter(mpdServersAdapter);
+        recyclerViewServers.setAdapter(playerSelectorAdapter);
 
         btnEnableMPD = view.findViewById(R.id.btnEnableMPD);
         btnAddMPDServer = view.findViewById(R.id.btnAddMPDServer);
@@ -107,7 +110,7 @@ public class MPDServersDialog extends BottomSheetDialogFragment {
 
 
         LiveData<List<MPDServerData>> servers = serversRepository.getAllServers();
-        servers.observe(this, mpdServers -> mpdServersAdapter.setEntries(mpdServers));
+        servers.observe(this, mpdServers -> playerSelectorAdapter.setEntries(mpdServers));
 
         updateUIReceiver = new BroadcastReceiver() {
             @Override

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/selector/PlayerType.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/selector/PlayerType.java
@@ -1,0 +1,43 @@
+package net.programmierecke.radiodroid2.players.selector;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+public enum PlayerType implements Parcelable {
+    MPD_SERVER(0),
+    RADIODROID(1),
+    EXTERNAL(2),
+    CAST(3);
+
+    private final int value;
+
+    PlayerType(final int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeInt(ordinal());
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    public static final Parcelable.Creator<PlayerType> CREATOR = new Parcelable.Creator<PlayerType>() {
+        @Override
+        public PlayerType createFromParcel(Parcel in) {
+            return PlayerType.values()[in.readInt()];
+        }
+
+        @Override
+        public PlayerType[] newArray(int size) {
+            return new PlayerType[size];
+        }
+    };
+}

--- a/app/src/main/java/net/programmierecke/radiodroid2/service/ConnectivityChecker.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/service/ConnectivityChecker.java
@@ -7,9 +7,10 @@ import android.content.IntentFilter;
 import android.net.ConnectivityManager;
 import android.net.Network;
 import android.net.NetworkCapabilities;
-import android.net.NetworkInfo;
 import android.net.NetworkRequest;
 import android.os.Build;
+
+import androidx.core.net.ConnectivityManagerCompat;
 
 public class ConnectivityChecker {
 
@@ -33,12 +34,7 @@ public class ConnectivityChecker {
 
     public static ConnectionType getCurrentConnectionType(Context context) {
         ConnectivityManager connectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-            return connectivityManager.isActiveNetworkMetered() ? ConnectionType.METERED : ConnectionType.NOT_METERED;
-        } else {
-            NetworkInfo wifiNetworkInfo = connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
-            return (wifiNetworkInfo != null && wifiNetworkInfo.isConnected()) ? ConnectionType.NOT_METERED : ConnectionType.METERED;
-        }
+        return ConnectivityManagerCompat.isActiveNetworkMetered(connectivityManager) ? ConnectionType.METERED : ConnectionType.NOT_METERED;
     }
 
     public void startListening(Context context, ConnectivityCallback connectivityCallback) {
@@ -67,15 +63,7 @@ public class ConnectivityChecker {
                 @Override
                 public void onReceive(Context context, Intent intent) {
                     boolean connected = !intent.hasExtra(ConnectivityManager.EXTRA_NO_CONNECTIVITY);
-
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-                        onConnectivityChanged(connected, connectivityManager.isActiveNetworkMetered() ? ConnectionType.METERED : ConnectionType.NOT_METERED);
-                    } else {
-                        // On API 15 there is no known to me way to check if connection is metered.
-                        NetworkInfo wifiNetworkInfo = connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
-                        onConnectivityChanged(connected, (wifiNetworkInfo != null && wifiNetworkInfo.isConnected()) ? ConnectionType.NOT_METERED : ConnectionType.METERED);
-                    }
-
+                    onConnectivityChanged(connected, ConnectivityManagerCompat.isActiveNetworkMetered(connectivityManager) ? ConnectionType.METERED : ConnectionType.NOT_METERED);
                 }
             };
             context.registerReceiver(networkBroadcastReceiver, new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION));

--- a/app/src/main/java/net/programmierecke/radiodroid2/service/HeadsetConnectionReceiver.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/service/HeadsetConnectionReceiver.java
@@ -15,6 +15,7 @@ import androidx.preference.PreferenceManager;
 import net.programmierecke.radiodroid2.HistoryManager;
 import net.programmierecke.radiodroid2.RadioDroidApp;
 import net.programmierecke.radiodroid2.Utils;
+import net.programmierecke.radiodroid2.players.selector.PlayerType;
 import net.programmierecke.radiodroid2.station.DataRadioStation;
 
 public class HeadsetConnectionReceiver extends BroadcastReceiver {
@@ -64,7 +65,7 @@ public class HeadsetConnectionReceiver extends BroadcastReceiver {
 
             if (lastStation != null) {
                 if (!PlayerServiceUtil.isPlaying() && !radioDroidApp.getMpdClient().isMpdEnabled()) {
-                    Utils.playAndWarnIfMetered(radioDroidApp, lastStation);
+                    Utils.playAndWarnIfMetered(radioDroidApp, lastStation, PlayerType.RADIODROID, () -> Utils.play(radioDroidApp, lastStation));
                 }
             }
         }

--- a/app/src/main/java/net/programmierecke/radiodroid2/service/PlayerService.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/service/PlayerService.java
@@ -686,7 +686,8 @@ public class PlayerService extends Service implements RadioPlayer.PlayerListener
             String error = "";
 
             PlayState currentPlayerState = radioPlayer.getPlayState();
-            if (currentPlayerState == PlayState.Paused && pauseReason == PauseReason.METERED_CONNECTION) {
+            if ((currentPlayerState == PlayState.Paused || currentPlayerState == PlayState.Idle)
+                    && pauseReason == PauseReason.METERED_CONNECTION) {
                 error = itsContext.getResources().getString(R.string.notify_metered_connection);
             } else {
                 try {
@@ -826,7 +827,8 @@ public class PlayerService extends Service implements RadioPlayer.PlayerListener
 
         PlayState currentPlayerState = radioPlayer.getPlayState();
 
-        if (currentPlayerState == PlayState.Paused && pauseReason == PauseReason.METERED_CONNECTION) {
+        if ((currentPlayerState == PlayState.Paused || currentPlayerState == PlayState.Idle)
+                && pauseReason == PauseReason.METERED_CONNECTION) {
             theMessage = itsContext.getResources().getString(R.string.notify_metered_connection);
         } else if (lastErrorFromPlayer != -1) {
             try {

--- a/app/src/main/java/net/programmierecke/radiodroid2/service/PlayerServiceUtil.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/service/PlayerServiceUtil.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 import android.content.ServiceConnection;
 import android.content.res.Resources;
 import android.os.IBinder;
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.os.RemoteException;
 import android.util.Log;
 
@@ -24,6 +26,7 @@ import net.programmierecke.radiodroid2.BuildConfig;
 import net.programmierecke.radiodroid2.IPlayerService;
 import net.programmierecke.radiodroid2.R;
 import net.programmierecke.radiodroid2.players.PlayState;
+import net.programmierecke.radiodroid2.players.selector.PlayerType;
 import net.programmierecke.radiodroid2.station.DataRadioStation;
 import net.programmierecke.radiodroid2.station.live.ShoutcastInfo;
 import net.programmierecke.radiodroid2.station.live.StreamLiveInfo;
@@ -419,10 +422,10 @@ public class PlayerServiceUtil {
         }
     }
 
-    public static void warnAboutMeteredConnection() {
+    public static void warnAboutMeteredConnection(PlayerType playerType) {
         if (itsPlayerService != null) {
             try {
-                itsPlayerService.warnAboutMeteredConnection();
+                itsPlayerService.warnAboutMeteredConnection(playerType);
             } catch (RemoteException e) {
                 Log.e("", "" + e);
             }

--- a/app/src/main/java/net/programmierecke/radiodroid2/service/PlayerServiceUtil.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/service/PlayerServiceUtil.java
@@ -418,4 +418,14 @@ public class PlayerServiceUtil {
             }
         }
     }
+
+    public static void warnAboutMeteredConnection() {
+        if (itsPlayerService != null) {
+            try {
+                itsPlayerService.warnAboutMeteredConnection();
+            } catch (RemoteException e) {
+                Log.e("", "" + e);
+            }
+        }
+    }
 }

--- a/app/src/main/java/net/programmierecke/radiodroid2/station/StationActions.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/station/StationActions.java
@@ -79,7 +79,7 @@ public class StationActions {
     }
 
     private static void retrieveAndCopyStreamUrlToClipboard(final @NonNull Context context, final @NonNull DataRadioStation station) {
-        context.sendBroadcast(new Intent(ActivityMain.ACTION_SHOW_LOADING));
+        LocalBroadcastManager.getInstance(context).sendBroadcast(new Intent(ActivityMain.ACTION_SHOW_LOADING));
 
         final WeakReference<Context> contextRef = new WeakReference<>(context);
 
@@ -147,7 +147,7 @@ public class StationActions {
     }
 
     public static void share(final @NonNull Context context, final @NonNull DataRadioStation station) {
-        context.sendBroadcast(new Intent(ActivityMain.ACTION_SHOW_LOADING));
+        LocalBroadcastManager.getInstance(context).sendBroadcast(new Intent(ActivityMain.ACTION_SHOW_LOADING));
 
         final WeakReference<Context> contextRef = new WeakReference<>(context);
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -186,7 +186,7 @@
     <string name="notify_pre_play">Connecting</string>
     <string name="notify_play">Playing</string>
     <string name="notify_paused">Paused</string>
-    <string name="notify_metered_connection">Warning! Metered connection detected</string>
+    <string name="notify_metered_connection">Metered connection!</string>
 
     <string name="notify_starred">Station has been added to favorites</string>
     <string name="notify_autostarred">Station has been automatically added to favorites</string>


### PR DESCRIPTION
- Now metered connection alert dialog will be dismissed if playback is started from other place rather than its "OK" button
- Renamed and slightly refactored `MPDServersDialog` because it's not mpd specific.
- Fixed metered warning with external player.
- Resuming after metered connection warning via media buttons are not reliable since sometimes we receive `Pause` event when playback is paused, instead of receiving `Play` event. However it's better than nothing.