### PR TITLE
Pause instead of stop on focus loss

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/service/PauseReason.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/service/PauseReason.java
@@ -8,6 +8,7 @@ public enum PauseReason implements Parcelable {
     NONE,
     BECAME_NOISY,
     FOCUS_LOSS,
+    FOCUS_LOSS_TRANSIENT,
     METERED_CONNECTION,
     USER;
 

--- a/app/src/main/java/net/programmierecke/radiodroid2/service/PlayerService.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/service/PlayerService.java
@@ -347,7 +347,7 @@ public class PlayerService extends Service implements RadioPlayer.PlayerListener
                         case AudioManager.AUDIOFOCUS_GAIN:
                             if (BuildConfig.DEBUG) Log.d(TAG, "audio focus gain");
 
-                            if (pauseReason == PauseReason.FOCUS_LOSS) {
+                            if (pauseReason == PauseReason.FOCUS_LOSS_TRANSIENT) {
                                 enableMediaSession();
                                 resume();
                             }
@@ -366,7 +366,7 @@ public class PlayerService extends Service implements RadioPlayer.PlayerListener
                             if (BuildConfig.DEBUG) Log.d(TAG, "audio focus loss transient");
 
                             if (radioPlayer.isPlaying()) {
-                                pause(PauseReason.FOCUS_LOSS);
+                                pause(PauseReason.FOCUS_LOSS_TRANSIENT);
                             }
 
                             break;

--- a/app/src/main/java/net/programmierecke/radiodroid2/service/PlayerService.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/service/PlayerService.java
@@ -357,7 +357,10 @@ public class PlayerService extends Service implements RadioPlayer.PlayerListener
                         case AudioManager.AUDIOFOCUS_LOSS:
                             if (BuildConfig.DEBUG) Log.d(TAG, "audio focus loss");
 
-                            stop();
+                            if (radioPlayer.isPlaying()) {
+                                pause(PauseReason.FOCUS_LOSS);
+                            }
+
                             break;
                         case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
                             if (BuildConfig.DEBUG) Log.d(TAG, "audio focus loss transient");


### PR DESCRIPTION
This should complete the adaptation to otherwise usual play/pause behaviour.

If you listen to RadioDroid and start a YouTube clip in between, you can simply continue listening to RadioDroid afterwards by using the notification.
