### PR TITLE
BecomingNoisyReceiver: Do not pause playback if it is already paused

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/service/BecomingNoisyReceiver.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/service/BecomingNoisyReceiver.java
@@ -12,7 +12,7 @@ public class BecomingNoisyReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        if (AudioManager.ACTION_AUDIO_BECOMING_NOISY.equals(intent.getAction())) {
+        if (AudioManager.ACTION_AUDIO_BECOMING_NOISY.equals(intent.getAction()) && PlayerServiceUtil.isPlaying()) {
             SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(context);
             if (sharedPref.getBoolean("pause_when_noisy", true)) {
                 PlayerServiceUtil.pause(PauseReason.BECAME_NOISY);


### PR DESCRIPTION
MediaSession now is running while playback is paused and ACTION_AUDIO_BECOMING_NOISY
could be received in paused state. However we do not want to change pause reason.

This fixes unexpected resumes of playback when headset is reconnected.