### PR TITLE
Upgrade ExoPlayer from 2.9.6 to 2.11.4

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply plugin: "de.mannodermaus.android-junit5"
 
 android {
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,7 @@ android {
 
     defaultConfig {
         applicationId "net.programmierecke.radiodroid2"
-        minSdkVersion 15
+        minSdkVersion 16
         targetSdkVersion 28
 
         versionCode 93
@@ -95,9 +95,9 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.squareup.picasso:picasso:2.71828'
     implementation 'jp.wasabeef:picasso-transformations:2.2.1'
-    implementation 'com.google.android.exoplayer:exoplayer-core:2.9.6'
-    implementation 'com.google.android.exoplayer:exoplayer-hls:2.9.6'
-    implementation 'com.google.android.exoplayer:exoplayer:2.9.6'
+    implementation 'com.google.android.exoplayer:exoplayer-core:2.11.3'
+    implementation 'com.google.android.exoplayer:exoplayer-hls:2.11.3'
+    implementation 'com.google.android.exoplayer:exoplayer:2.11.3'
     implementation "com.mikepenz:iconics-core:4.0.2"
     implementation 'com.mikepenz:google-material-typeface:3.0.1.4.original-kotlin@aar'
     implementation 'com.mikepenz:community-material-typeface:3.5.95.1-kotlin@aar'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -127,7 +127,6 @@ dependencies {
     playImplementation 'com.google.android.gms:play-services-safetynet:17.0.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.1'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.6.1'
 }
 
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -125,8 +125,8 @@ dependencies {
     playImplementation 'com.google.android.gms:play-services-cast:18.1.0'
     playImplementation 'com.google.android.gms:play-services-cast-framework:18.1.0'
     playImplementation 'com.google.android.gms:play-services-safetynet:17.0.0'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.1'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.2'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.2'
 }
 
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -95,9 +95,9 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.squareup.picasso:picasso:2.71828'
     implementation 'jp.wasabeef:picasso-transformations:2.2.1'
-    implementation 'com.google.android.exoplayer:exoplayer-core:2.11.3'
-    implementation 'com.google.android.exoplayer:exoplayer-hls:2.11.3'
-    implementation 'com.google.android.exoplayer:exoplayer:2.11.3'
+    implementation 'com.google.android.exoplayer:exoplayer-core:2.11.4'
+    implementation 'com.google.android.exoplayer:exoplayer-hls:2.11.4'
+    implementation 'com.google.android.exoplayer:exoplayer:2.11.4'
     implementation "com.mikepenz:iconics-core:4.0.2"
     implementation 'com.mikepenz:google-material-typeface:3.0.1.4.original-kotlin@aar'
     implementation 'com.mikepenz:community-material-typeface:3.5.95.1-kotlin@aar'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,6 +67,13 @@ android {
             dimension "one"
         }
     }
+
+    testOptions {
+        unitTests.all {
+            useJUnit()
+        }
+        unitTests.returnDefaultValues = true
+    }
 }
 
 def getLastFMApiKey() {
@@ -117,6 +124,9 @@ dependencies {
     playImplementation 'com.google.android.gms:play-services-cast:18.1.0'
     playImplementation 'com.google.android.gms:play-services-cast-framework:18.1.0'
     playImplementation 'com.google.android.gms:play-services-safetynet:17.0.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.1'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.6.1'
 }
 
 

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/ExoPlayerWrapper.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/ExoPlayerWrapper.java
@@ -108,6 +108,10 @@ public class ExoPlayerWrapper implements PlayerWrapper, IcyDataSource.IcyDataSou
                 IOException exception,
                 int errorCount) {
             int retryDelay = sharedPrefs.getInt("settings_retry_delay", 100);;
+            if (!Utils.hasAnyConnection(context)) {
+                resumeWhenNetworkConnected();
+                retryDelay = 1000 * sharedPrefs.getInt("settings_resume_within", 60);
+            }
             if (BuildConfig.DEBUG) {
                 Log.d(TAG, "Providing retry delay of " + retryDelay + "ms for: data type " + dataType + ", load duration: " + loadDurationMs + "ms, error count: " + errorCount + ", exception: " + exception.getClass() + ", message: " + exception.getMessage());
             }
@@ -306,7 +310,9 @@ public class ExoPlayerWrapper implements PlayerWrapper, IcyDataSource.IcyDataSou
     @Override
     public void onDataSourceConnectionLostIrrecoverably() {
         Log.i(TAG, "Connection lost irrecoverably.");
+    }
 
+    void resumeWhenNetworkConnected() {
         playerThreadHandler.post(() -> {
             SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(context);
             int resumeWithin = sharedPref.getInt("settings_resume_within", 60);

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/ExoPlayerWrapper.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/ExoPlayerWrapper.java
@@ -40,6 +40,7 @@ import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
 import com.google.android.exoplayer2.upstream.DefaultLoadErrorHandlingPolicy;
+import com.google.android.exoplayer2.upstream.HttpDataSource;
 
 import net.programmierecke.radiodroid2.BuildConfig;
 import net.programmierecke.radiodroid2.R;
@@ -109,7 +110,14 @@ public class ExoPlayerWrapper implements PlayerWrapper, IcyDataSource.IcyDataSou
                 long loadDurationMs,
                 IOException exception,
                 int errorCount) {
+
             int retryDelay = getSanitizedRetryDelaySettingsMs();
+
+            if (exception instanceof HttpDataSource.InvalidContentTypeException) {
+                stateListener.onPlayerError(R.string.error_play_stream);
+                return C.TIME_UNSET; // Immediately surface error if we cannot play content type
+            }
+
             if (!Utils.hasAnyConnection(context)) {
                 resumeWhenNetworkConnected();
                 retryDelay = 1000 * sharedPrefs.getInt("settings_resume_within", 60);

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/ExoPlayerWrapper.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/ExoPlayerWrapper.java
@@ -162,8 +162,8 @@ public class ExoPlayerWrapper implements PlayerWrapper, IcyDataSource.IcyDataSou
         isHls = streamUrl.endsWith(".m3u8");
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext());
-        final int retryTimeout = prefs.getInt("settings_retry_timeout", 4);
-        final int retryDelay = prefs.getInt("settings_retry_delay", 10);
+        final int retryTimeout = prefs.getInt("settings_retry_timeout", 10);
+        final int retryDelay = prefs.getInt("settings_retry_delay", 100);
 
         DataSource.Factory dataSourceFactory = new RadioDataSourceFactory(httpClient, bandwidthMeter, this, retryTimeout, retryDelay);
         // Produces Extractor instances for parsing the media data.

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/ExoPlayerWrapper.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/ExoPlayerWrapper.java
@@ -343,7 +343,7 @@ public class ExoPlayerWrapper implements PlayerWrapper, IcyDataSource.IcyDataSou
                 };
                 playerThreadHandler.postDelayed(fullStopTask, resumeWithin * 1000);
 
-                stateListener.onPlayerWarning(R.string.error_stream_reconnect_timeout);
+                stateListener.onPlayerWarning(R.string.warning_no_network_trying_resume);
             } else {
                 stop();
 

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/ExoPlayerWrapper.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/ExoPlayerWrapper.java
@@ -119,9 +119,13 @@ public class ExoPlayerWrapper implements PlayerWrapper, IcyDataSource.IcyDataSou
             }
 
             if (!Utils.hasAnyConnection(context)) {
-                resumeWhenNetworkConnected();
-                retryDelay = 1000 * sharedPrefs.getInt("settings_resume_within", 60);
+                int resumeWithinS = sharedPrefs.getInt("settings_resume_within", 60);
+                if (resumeWithinS > 0) {
+                    resumeWhenNetworkConnected();
+                    retryDelay = 1000 * resumeWithinS + retryDelay;
+                }
             }
+
             if (BuildConfig.DEBUG) {
                 Log.d(TAG, "Providing retry delay of " + retryDelay + "ms for: data type " + dataType + ", load duration: " + loadDurationMs + "ms, error count: " + errorCount + ", exception: " + exception.getClass() + ", message: " + exception.getMessage());
             }

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/ExoPlayerWrapper.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/ExoPlayerWrapper.java
@@ -427,6 +427,7 @@ public class ExoPlayerWrapper implements PlayerWrapper, IcyDataSource.IcyDataSou
 
         @Override
         public void onPlayerError(ExoPlaybackException error) {
+            Log.d(TAG, "Player error: ", error);
             // Stop playing since it is either irrecoverable error in the player or our data source failed to reconnect.
             if (fullStopTask != null || error.type != ExoPlaybackException.TYPE_SOURCE) {
                 stop();
@@ -504,7 +505,7 @@ public class ExoPlayerWrapper implements PlayerWrapper, IcyDataSource.IcyDataSou
 
         @Override
         public void onPlayerError(EventTime eventTime, ExoPlaybackException error) {
-
+            Log.d(TAG, "Player error at playback position " + eventTime.currentPlaybackPositionMs + "ms: ", error);
         }
 
         @Override

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/ExoPlayerWrapper.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/ExoPlayerWrapper.java
@@ -274,12 +274,14 @@ public class ExoPlayerWrapper implements PlayerWrapper, IcyDataSource.IcyDataSou
                     }
                     if (entry instanceof IcyInfo) {
                         final IcyInfo icyInfo = ((IcyInfo) entry);
-                        Log.d(TAG, "IcyInfo: " + icyInfo.title);
-                        Map<String, String> rawMetadata =  new HashMap<String, String>() {{
-                            put("StreamTitle", icyInfo.title);
-                        }};
-                        StreamLiveInfo streamLiveInfo = new StreamLiveInfo(rawMetadata);
-                        onDataSourceStreamLiveInfo(streamLiveInfo);
+                        Log.d(TAG, "IcyInfo: " + icyInfo.toString());
+                        if (icyInfo.title != null) {
+                            Map<String, String> rawMetadata = new HashMap<String, String>() {{
+                                put("StreamTitle", icyInfo.title);
+                            }};
+                            StreamLiveInfo streamLiveInfo = new StreamLiveInfo(rawMetadata);
+                            onDataSourceStreamLiveInfo(streamLiveInfo);
+                        }
                     } else if (entry instanceof IcyHeaders) {
                         final IcyHeaders icyHeaders = ((IcyHeaders) entry);
                         Log.d(TAG, "IcyHeaders: " + icyHeaders.toString());

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/IcyDataSource.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/IcyDataSource.java
@@ -205,7 +205,7 @@ public class IcyDataSource implements HttpDataSource {
         }
 
         if (bytesRead > metadataBytesToSkip) {
-            dataSourceListener.onDataSourceBytesRead(buffer, offset +  metadataBytesToSkip, bytesRead - metadataBytesToSkip);
+            dataSourceListener.onDataSourceBytesRead(buffer, offset + metadataBytesToSkip, bytesRead - metadataBytesToSkip);
             metadataBytesToSkip = 0;
         } else {
             metadataBytesToSkip -= bytesRead;

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/IcyDataSource.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/IcyDataSource.java
@@ -185,8 +185,7 @@ public class IcyDataSource implements HttpDataSource {
             return bytesTransferred;
         } catch (HttpDataSourceException readError) {
             dataSourceListener.onDataSourceConnectionLost();
-            dataSourceListener.onDataSourceConnectionLostIrrecoverably();
-            throw new HttpDataSourceException("Reconnection retry time ended.", dataSpec, HttpDataSourceException.TYPE_READ);
+            throw readError;
         }
     }
 

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/RadioDataSourceFactory.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/RadioDataSourceFactory.java
@@ -29,6 +29,6 @@ public class RadioDataSourceFactory implements DataSource.Factory {
 
     @Override
     public DataSource createDataSource() {
-        return new IcyDataSource(httpClient, transferListener, dataSourceListener, retryTimeout, retryDelay);
+        return new IcyDataSource(httpClient, transferListener, dataSourceListener);
     }
 }

--- a/app/src/main/java/net/programmierecke/radiodroid2/station/live/ShoutcastInfo.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/station/live/ShoutcastInfo.java
@@ -3,6 +3,8 @@ package net.programmierecke.radiodroid2.station.live;
 import android.os.Parcel;
 import android.os.Parcelable;
 
+import com.google.android.exoplayer2.metadata.icy.IcyHeaders;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -33,6 +35,14 @@ public class ShoutcastInfo implements Parcelable {
     public int sampleRate;
 
     public ShoutcastInfo() {
+    }
+
+    public ShoutcastInfo(IcyHeaders icyHeaders) {
+        this.bitrate = icyHeaders.bitrate;
+        this.audioGenre = icyHeaders.genre;
+        this.serverPublic = icyHeaders.isPublic;
+        this.audioName = icyHeaders.name;
+        this.audioHomePage = icyHeaders.url;
     }
 
     public static ShoutcastInfo Decode(Response response) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -228,6 +228,7 @@
     <string name="error_caching_stream">Stream caching problem</string>
     <string name="error_play_stream">Unable to play stream</string>
     <string name="error_stream_reconnect_timeout">Unable to reconnect to the stream: timeout</string>
+    <string name="warning_no_network_trying_resume">No network connection. Trying to resume when connection is back.</string>
     <string name="giving_up_resume">Attempt to resume playback ignored</string>
 
     <string name="error_record_needs_write">Need write permission for recording</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -227,7 +227,7 @@
             search:summary=""
             android:title="@string/settings_retry_timeout" />
         <net.programmierecke.radiodroid2.views.IntEditTextPreference
-            android:defaultValue="0"
+            android:defaultValue="100"
             android:key="settings_retry_delay"
             android:maxLength="8"
             android:summary="@string/settings_milliseconds_format"

--- a/app/src/test/java/net/programmierecke/radiodroid2/players/exoplayer/IcyDataSourceTest.java
+++ b/app/src/test/java/net/programmierecke/radiodroid2/players/exoplayer/IcyDataSourceTest.java
@@ -1,0 +1,136 @@
+package net.programmierecke.radiodroid2.players.exoplayer;
+
+import androidx.annotation.Nullable;
+
+import com.google.android.exoplayer2.upstream.DataSource;
+import com.google.android.exoplayer2.upstream.DataSpec;
+import com.google.android.exoplayer2.upstream.TransferListener;
+
+import net.programmierecke.radiodroid2.station.live.ShoutcastInfo;
+import net.programmierecke.radiodroid2.station.live.StreamLiveInfo;
+
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import okhttp3.OkHttpClient;
+
+
+class IcyDataSourceTest {
+    private static IcyDataSource icyDataSource;
+    private static StringBuffer transferredBytesWithoutMetadata;
+
+    @BeforeAll
+    public static void setup() {
+        icyDataSource = new IcyDataSource(new OkHttpClient(), new TestTransferListener(), new TestDataSourceListener());
+        icyDataSource.shoutcastInfo = new ShoutcastInfo();
+        icyDataSource.shoutcastInfo.metadataOffset = 16000;
+    }
+
+    @BeforeEach
+    void init() {
+        transferredBytesWithoutMetadata = new StringBuffer();
+    }
+
+    @Test
+    void sendToDataSourceListenersWithoutMetadata_canHandleMultipleMetadataFrames() {
+        final byte[] buffer = "OFFSETaudio1audio2\u0001METADATAMETADATAaudio3audio4audio5\u0002METADATAMETADATAMETADATAMETADATAaudio6".getBytes();
+        final int offset = 6;
+        icyDataSource.remainingUntilMetadata = "audioN".length() * 2;
+        icyDataSource.shoutcastInfo.metadataOffset = "audioN".length() * 3;
+        icyDataSource.metadataBytesToSkip = 0;
+        icyDataSource.sendToDataSourceListenersWithoutMetadata(buffer, offset, buffer.length - offset);
+        assertEquals("audio1audio2audio3audio4audio5audio6", transferredBytesWithoutMetadata.toString());
+        assertEquals(icyDataSource.shoutcastInfo.metadataOffset - "audioN".length(), icyDataSource.remainingUntilMetadata);
+        assertEquals(0, icyDataSource.metadataBytesToSkip);
+    }
+
+    @Test
+    void sendToDataSourceListenersWithoutMetadata_canHandleIncompleteMetaDataFrames() {
+        final byte[] buffer = "OFFSETaudio7audio8\u0001METADATAMETADATAaudio9audioAaudioB\u0001META".getBytes();
+        final int offset = 6;
+        icyDataSource.remainingUntilMetadata = "audioN".length() * 2;
+        icyDataSource.shoutcastInfo.metadataOffset = "audioN".length() * 3;
+        icyDataSource.metadataBytesToSkip = 0;
+        icyDataSource.sendToDataSourceListenersWithoutMetadata(buffer, offset, buffer.length - offset);
+        assertEquals("audio7audio8audio9audioAaudioB", transferredBytesWithoutMetadata.toString());
+        assertEquals(16 - "META".length(), icyDataSource.metadataBytesToSkip);
+        assertEquals(icyDataSource.shoutcastInfo.metadataOffset + 16 - "META".length(), icyDataSource.remainingUntilMetadata);
+    }
+
+    @Test
+    void sendToDataSourceListenersWithoutMetadata_canHandleInterruptedMetadata() {
+        sendToDataSourceListenersWithoutMetadata_canHandleIncompleteMetaDataFrames();
+        final byte[] buffer = "DATAMETADATAaudioCaudioDaudioE\u0001METADATAMETADATAaudioF".getBytes();
+        icyDataSource.sendToDataSourceListenersWithoutMetadata(buffer, 0, buffer.length);
+        assertEquals("audio7audio8audio9audioAaudioBaudioCaudioDaudioEaudioF", transferredBytesWithoutMetadata.toString());
+        assertEquals(0, icyDataSource.metadataBytesToSkip);
+        assertEquals("audioN".length() * 2, icyDataSource.remainingUntilMetadata);
+    }
+
+    @Test
+    void sendToDataSourceListenersWithoutMetadata_canHandleInterruptedAudioData() {
+        sendToDataSourceListenersWithoutMetadata_canHandleMultipleMetadataFrames();
+        final byte[] buffer = "audio7audio8".getBytes();
+        icyDataSource.sendToDataSourceListenersWithoutMetadata(buffer, 0, buffer.length);
+        assertEquals("audio1audio2audio3audio4audio5audio6audio7audio8", transferredBytesWithoutMetadata.toString());
+        assertEquals(0, icyDataSource.metadataBytesToSkip);
+        assertEquals(0, icyDataSource.metadataBytesToSkip);
+    }
+
+    static class TestDataSourceListener implements IcyDataSource.IcyDataSourceListener {
+
+        @Override
+        public void onDataSourceConnected() {
+
+        }
+
+        @Override
+        public void onDataSourceConnectionLost() {
+
+        }
+
+        @Override
+        public void onDataSourceConnectionLostIrrecoverably() {
+
+        }
+
+        @Override
+        public void onDataSourceShoutcastInfo(@Nullable ShoutcastInfo shoutcastInfo) {
+
+        }
+
+        @Override
+        public void onDataSourceStreamLiveInfo(StreamLiveInfo streamLiveInfo) {
+
+        }
+
+        @Override
+        public void onDataSourceBytesRead(byte[] buffer, int offset, int length) {
+            transferredBytesWithoutMetadata.append(new String(buffer, offset,length));
+        }
+    }
+
+    static class TestTransferListener implements TransferListener {
+
+        @Override
+        public void onTransferInitializing(DataSource source, DataSpec dataSpec, boolean isNetwork) {
+
+        }
+
+        @Override
+        public void onTransferStart(DataSource source, DataSpec dataSpec, boolean isNetwork) {
+
+        }
+
+        @Override
+        public void onBytesTransferred(DataSource source, DataSpec dataSpec, boolean isNetwork, int bytesTransferred) {
+
+        }
+
+        @Override
+        public void onTransferEnd(DataSource source, DataSpec dataSpec, boolean isNetwork) {
+
+        }
+    }
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.6.0'
+        classpath "de.mannodermaus.gradle.plugins:android-junit5:1.3.2.0"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.6.3'
-        classpath "de.mannodermaus.gradle.plugins:android-junit5:1.3.2.0"
+        classpath "de.mannodermaus.gradle.plugins:android-junit5:1.6.0.0"
     }
 }
 


### PR DESCRIPTION
It seems to work just fine. The biggest issue is probably the required increase of minSdkVersion from 15 to 16.

For now I've left all the original callbacks of our `IcyDataSource` and used the original routines to spread the metadata that's now received with the new callback `onMetadata` in `ExoPlayerWrapper`.

One positive effect ist already that the ExoPlayer metadata reader seems to convert some latin encodings to utf8.

I don't know, if we really want or need to make the upgrade, but with this PR we can already play around with it.
