### PR TITLE
Fix menu background color in lower APIs

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -34,6 +34,7 @@
 
         <item name="colorTabUnderline">@color/colorTabUnderline</item>
 
+        <item name="android:itemBackground">@color/windowBackground</item>
         <item name="iconsInItemBackgroundColor">@color/iconsInItemBackgroundColor</item>
 
         <item name="met_baseColor">?android:textColorPrimary</item>
@@ -75,6 +76,7 @@
 
         <item name="colorTabUnderline">@color/colorTabUnderlineDark</item>
 
+        <item name="android:itemBackground">@color/windowBackgroundDark</item>
         <item name="iconsInItemBackgroundColor">@color/iconsInItemBackgroundColorDark</item>
 
         <item name="met_baseColor">?android:textColorPrimary</item>


### PR DESCRIPTION
On API 16, the actionbar menu background stayed white also in dark mode,
resulting in white on white print, since fb9ed131a0186885412b90e2d3d5766172774449. This patch ensures that the menu background is changed on theme changes.