### PR TITLE
Fix play-pause icons going out of sync

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentPlayerFull.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentPlayerFull.java
@@ -309,12 +309,11 @@ public class FragmentPlayerFull extends Fragment {
                     }
 
                     PlayerServiceUtil.pause(PauseReason.USER);
-
-                    updatePlaybackButtons(false, false);
                 } else {
                     playLastFromHistory();
-                    updatePlaybackButtons(true, false);
                 }
+
+                updatePlaybackButtons(PlayerServiceUtil.isPlaying(), PlayerServiceUtil.isRecording());
             }
         });
 

--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentPlayerSmall.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentPlayerSmall.java
@@ -106,16 +106,12 @@ public class FragmentPlayerSmall extends Fragment {
 
         buttonPlay.setOnClickListener(v -> {
             if (PlayerServiceUtil.isPlaying()) {
-                buttonPlay.setImageResource(R.drawable.ic_play_circle);
-                buttonPlay.setContentDescription(getResources().getString(R.string.detail_play));
                 if (PlayerServiceUtil.isRecording()) {
                     PlayerServiceUtil.stopRecording();
                 }
 
                 PlayerServiceUtil.pause(PauseReason.USER);
             } else {
-                buttonPlay.setImageResource(R.drawable.ic_pause_circle);
-                buttonPlay.setContentDescription(getResources().getString(R.string.detail_pause));
                 playLastFromHistory();
             }
         });

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/selector/PlayerSelectorAdapter.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/selector/PlayerSelectorAdapter.java
@@ -134,6 +134,15 @@ public class PlayerSelectorAdapter extends RecyclerView.Adapter<RecyclerView.Vie
         this.actionListener = actionListener;
     }
 
+    public void notifyRadioDroidPlaybackStateChanged() {
+        if (stationToPlay != null) {
+            int pos = viewTypes.indexOf(PlayerType.RADIODROID.getValue());
+            if (pos != -1) {
+                notifyItemChanged(pos);
+            }
+        }
+    }
+
     @NonNull
     @Override
     public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
@@ -174,15 +183,9 @@ public class PlayerSelectorAdapter extends RecyclerView.Adapter<RecyclerView.Vie
                     }
 
                     PlayerServiceUtil.pause(PauseReason.USER);
-
-                    holder.btnPlay.setImageResource(R.drawable.ic_play_circle);
-                    holder.btnPlay.setContentDescription(context.getString(R.string.detail_play));
                 } else {
                     Utils.playAndWarnIfMetered((RadioDroidApp) context.getApplicationContext(), stationToPlay, PlayerType.RADIODROID,
                             () -> Utils.play((RadioDroidApp) context.getApplicationContext(), stationToPlay));
-
-                    holder.btnPlay.setImageResource(R.drawable.ic_pause_circle);
-                    holder.btnPlay.setContentDescription(context.getResources().getString(R.string.detail_pause));
                 }
             });
         } else if (holder.getItemViewType() == PlayerType.EXTERNAL.getValue()) {

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/selector/PlayerSelectorDialog.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/selector/PlayerSelectorDialog.java
@@ -116,7 +116,7 @@ public class PlayerSelectorDialog extends BottomSheetDialogFragment {
             @Override
             public void onReceive(Context context, Intent intent) {
                 if (PlayerService.PLAYER_SERVICE_STATE_CHANGE.equals(intent.getAction())) {
-                    // fullUpdate();
+                    playerSelectorAdapter.notifyRadioDroidPlaybackStateChanged();
                 }
             }
         };


### PR DESCRIPTION
Play buttons now should be updated by PlayerService's state only.
Since we have PrePlaying state set nearly immediately after
button press - we should not set icons predictively.