### PR TITLE
Revert "Update okhttp to 3.12.9"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -90,7 +90,7 @@ dependencies {
 
     // Keep OkHttp 3.12.X to support Android 4.X, see https://developer.squareup.com/blog/okhttp-3-13-requires-android-5
     //noinspection GradleDependency
-    implementation 'com.squareup.okhttp3:okhttp:3.12.9'
+    implementation 'com.squareup.okhttp3:okhttp:3.12.8'
 
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.squareup.picasso:picasso:2.71828'


### PR DESCRIPTION
It should not, but does break API 16 compatibility.

This reverts commit f931e70235da236bd723b34d1e3c244756feeed7.