### PR TITLE
Improve the process of removal from favourites

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/FavouriteManager.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FavouriteManager.java
@@ -40,6 +40,13 @@ public class FavouriteManager extends StationSaveManager {
     }
 
     @Override
+    public void restore(DataRadioStation station, int pos) {
+        if (!has(station.StationUuid)) {
+            super.restore(station, pos);
+        }
+    }
+
+    @Override
     void Load() {
         super.Load();
         updateShortcuts();

--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentHistory.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentHistory.java
@@ -66,7 +66,7 @@ public class FragmentHistory extends Fragment implements IAdapterRefreshable {
                 RefreshListGui();
 
                 Snackbar snackbar = Snackbar
-                        .make(rvStations, R.string.notify_station_removed_from_list, Snackbar.LENGTH_LONG);
+                        .make(rvStations, R.string.notify_station_removed_from_list, 6000);
                 snackbar.setAnchorView(getView().getRootView().findViewById(R.id.bottom_sheet));
                 snackbar.setAction(R.string.action_station_removed_from_list_undo, new View.OnClickListener() {
                     @Override
@@ -76,7 +76,6 @@ public class FragmentHistory extends Fragment implements IAdapterRefreshable {
                     }
                 });
                 snackbar.setActionTextColor(Color.GREEN);
-                snackbar.setDuration(Snackbar.LENGTH_LONG);
                 snackbar.show();
             }
 

--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentHistory.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentHistory.java
@@ -75,7 +75,6 @@ public class FragmentHistory extends Fragment implements IAdapterRefreshable {
                         RefreshListGui();
                     }
                 });
-                snackbar.setActionTextColor(Color.GREEN);
                 snackbar.show();
             }
 

--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentHistory.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentHistory.java
@@ -17,6 +17,7 @@ import com.google.android.material.snackbar.Snackbar;
 import net.programmierecke.radiodroid2.station.ItemAdapterStation;
 import net.programmierecke.radiodroid2.station.DataRadioStation;
 import net.programmierecke.radiodroid2.interfaces.IAdapterRefreshable;
+import net.programmierecke.radiodroid2.station.StationActions;
 import net.programmierecke.radiodroid2.station.StationsFilter;
 
 public class FragmentHistory extends Fragment implements IAdapterRefreshable {

--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentPlayerFull.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentPlayerFull.java
@@ -344,7 +344,7 @@ public class FragmentPlayerFull extends Fragment {
             }
 
             if (favouriteManager.has(station.StationUuid)) {
-                StationActions.removeFromFavourites(requireContext(), station);
+                StationActions.removeFromFavourites(requireContext(), null, station);
             } else {
                 StationActions.markAsFavourite(requireContext(), station);
             }

--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentPlayerSmall.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentPlayerSmall.java
@@ -286,7 +286,7 @@ public class FragmentPlayerSmall extends Fragment {
                 }
                 case R.id.action_bookmark: {
                     if (stationIsInFavourites) {
-                        StationActions.removeFromFavourites(requireContext(), currentStation);
+                        StationActions.removeFromFavourites(requireContext(), getView(), currentStation);
                     } else {
                         StationActions.markAsFavourite(requireContext(), currentStation);
                     }

--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentStarred.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentStarred.java
@@ -25,6 +25,7 @@ import net.programmierecke.radiodroid2.station.ItemAdapterStation;
 import net.programmierecke.radiodroid2.station.DataRadioStation;
 import net.programmierecke.radiodroid2.station.ItemAdapterIconOnlyStation;
 import net.programmierecke.radiodroid2.interfaces.IAdapterRefreshable;
+import net.programmierecke.radiodroid2.station.StationActions;
 import net.programmierecke.radiodroid2.station.StationsFilter;
 
 import java.util.Objects;
@@ -98,21 +99,7 @@ public class FragmentStarred extends Fragment implements IAdapterRefreshable, Ob
 
             @Override
             public void onStationSwiped(final DataRadioStation station) {
-                final int removedIdx = favouriteManager.remove(station.StationUuid);
-
-                Snackbar snackbar = Snackbar
-                        .make(rvStations, R.string.notify_station_removed_from_list, Snackbar.LENGTH_LONG);
-                snackbar.setAnchorView(getView().getRootView().findViewById(R.id.bottom_sheet));
-                snackbar.setAction(R.string.action_station_removed_from_list_undo, new View.OnClickListener() {
-                    @Override
-                    public void onClick(View view) {
-                        favouriteManager.restore(station, removedIdx);
-                        RefreshListGui();
-                    }
-                });
-                snackbar.setActionTextColor(Color.GREEN);
-                snackbar.setDuration(BaseTransientBottomBar.LENGTH_LONG);
-                snackbar.show();
+                StationActions.removeFromFavourites(requireContext(), getView(), station);
             }
 
             @Override

--- a/app/src/main/java/net/programmierecke/radiodroid2/station/ItemAdapterStation.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/station/ItemAdapterStation.java
@@ -271,7 +271,7 @@ public class ItemAdapterStation
                     @Override
                     public void onClick(View view) {
                         if (favouriteManager.has(station.StationUuid)) {
-                            StationActions.removeFromFavourites(getContext(), station);
+                            StationActions.removeFromFavourites(getContext(), view, station);
                         } else {
                             StationActions.markAsFavourite(getContext(), station);
                         }
@@ -385,7 +385,7 @@ public class ItemAdapterStation
                 holder.buttonBookmark.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View view) {
-                        StationActions.removeFromFavourites(getContext(), station);
+                        StationActions.removeFromFavourites(getContext(), view, station);
 
                         int position = holder.getAdapterPosition();
                         notifyItemChanged(position);

--- a/app/src/main/java/net/programmierecke/radiodroid2/station/StationActions.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/station/StationActions.java
@@ -152,11 +152,10 @@ public class StationActions {
             final View viewAttachTo = view.getRootView().findViewById(R.id.fragment_player_small);
 
             Snackbar snackbar = Snackbar
-                    .make(viewAttachTo, R.string.notify_station_removed_from_list, Snackbar.LENGTH_LONG);
+                    .make(viewAttachTo, R.string.notify_station_removed_from_list, 6000);
             snackbar.setAnchorView(viewAttachTo);
             snackbar.setAction(R.string.action_station_removed_from_list_undo, view1 -> favouriteManager.restore(station, removedIdx));
             snackbar.setActionTextColor(Color.GREEN);
-            snackbar.setDuration(BaseTransientBottomBar.LENGTH_LONG);
             snackbar.show();
         }
     }

--- a/app/src/main/java/net/programmierecke/radiodroid2/station/StationActions.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/station/StationActions.java
@@ -6,19 +6,26 @@ import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.graphics.Color;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.text.TextUtils;
 import android.util.Log;
+import android.view.View;
 import android.widget.TimePicker;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.FragmentActivity;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
+import com.google.android.material.snackbar.BaseTransientBottomBar;
+import com.google.android.material.snackbar.Snackbar;
+
 import net.programmierecke.radiodroid2.ActivityMain;
+import net.programmierecke.radiodroid2.FavouriteManager;
 import net.programmierecke.radiodroid2.R;
 import net.programmierecke.radiodroid2.RadioBrowserServerManager;
 import net.programmierecke.radiodroid2.RadioDroidApp;
@@ -136,12 +143,22 @@ public class StationActions {
         vote(context, station);
     }
 
-    public static void removeFromFavourites(final @NonNull Context context, final @NonNull DataRadioStation station) {
+    public static void removeFromFavourites(final @NonNull Context context, final @Nullable View view, final @NonNull DataRadioStation station) {
         final RadioDroidApp radioDroidApp = (RadioDroidApp) context.getApplicationContext();
-        radioDroidApp.getFavouriteManager().remove(station.StationUuid);
+        final FavouriteManager favouriteManager = radioDroidApp.getFavouriteManager();
+        final int removedIdx = favouriteManager.remove(station.StationUuid);
 
-        Toast toast = Toast.makeText(context, context.getString(R.string.notify_unstarred), Toast.LENGTH_SHORT);
-        toast.show();
+        if (view != null) {
+            final View viewAttachTo = view.getRootView().findViewById(R.id.fragment_player_small);
+
+            Snackbar snackbar = Snackbar
+                    .make(viewAttachTo, R.string.notify_station_removed_from_list, Snackbar.LENGTH_LONG);
+            snackbar.setAnchorView(viewAttachTo);
+            snackbar.setAction(R.string.action_station_removed_from_list_undo, view1 -> favouriteManager.restore(station, removedIdx));
+            snackbar.setActionTextColor(Color.GREEN);
+            snackbar.setDuration(BaseTransientBottomBar.LENGTH_LONG);
+            snackbar.show();
+        }
     }
 
     public static void share(final @NonNull Context context, final @NonNull DataRadioStation station) {

--- a/app/src/main/java/net/programmierecke/radiodroid2/station/StationActions.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/station/StationActions.java
@@ -155,7 +155,6 @@ public class StationActions {
                     .make(viewAttachTo, R.string.notify_station_removed_from_list, 6000);
             snackbar.setAnchorView(viewAttachTo);
             snackbar.setAction(R.string.action_station_removed_from_list_undo, view1 -> favouriteManager.restore(station, removedIdx));
-            snackbar.setActionTextColor(Color.GREEN);
             snackbar.show();
         }
     }

--- a/app/src/main/java/net/programmierecke/radiodroid2/utils/RecyclerItemSwipeHelper.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/utils/RecyclerItemSwipeHelper.java
@@ -3,6 +3,7 @@ package net.programmierecke.radiodroid2.utils;
 import android.graphics.Canvas;
 import android.view.View;
 
+import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.ItemTouchHelper;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -67,5 +68,17 @@ public class RecyclerItemSwipeHelper<ViewHolderType extends SwipeableViewHolder>
         @SuppressWarnings("unchecked")
         ViewHolderType viewHolderType = (ViewHolderType) viewHolder;
         swipeListener.onSwiped(viewHolderType, direction);
+    }
+
+    @Override
+    public float getSwipeVelocityThreshold(float defaultValue) {
+        // Effectively disable flinging because it's too easy to accidentally perform it.
+        return 1;
+    }
+
+    @Override
+    public float getSwipeThreshold(@NonNull RecyclerView.ViewHolder viewHolder) {
+        // Since flinging is disabled we reduce swipe threshold.
+        return 0.35f;
     }
 }

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -38,4 +38,7 @@
     <color name="iconsInItemBackgroundColorDark">@android:color/white</color>
 
     <color name="startRecordingColor">#ff3333</color>
+
+    <color name="snackBarButtonColor">#D500F9</color>
+    <color name="snackBarButtonColorDark">@color/snackBarButtonColor</color>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -41,6 +41,8 @@
         <item name="met_textColorHint">?android:textColorHint</item>
         <item name="met_primaryColor">?android:colorPrimary</item>
 
+        <item name="snackbarButtonStyle">@style/SnackBarButton</item>
+
         <!-- workaround for lower API -->
         <item name="colorAccentMy">@color/colorAccent</item>
 
@@ -82,6 +84,8 @@
         <item name="met_baseColor">?android:textColorPrimary</item>
         <item name="met_textColorHint">?android:textColorHint</item>
         <item name="met_primaryColor">?android:colorPrimaryDark</item>
+
+        <item name="snackbarButtonStyle">@style/SnackBarButtonDark</item>
 
         <!-- workaround for lower API -->
         <item name="colorAccentMy">@color/colorAccentDark</item>
@@ -135,5 +139,13 @@
 
     <style name="MenuTextAppearance" parent="@android:style/TextAppearance.Widget.IconMenu.Item">
         <item name="android:textColor">@color/textColorPrimary</item>
+    </style>
+
+    <style name="SnackBarButton" parent="@style/Widget.MaterialComponents.Button.TextButton.Snackbar">
+        <item name="android:textColor">@color/snackBarButtonColor</item>
+    </style>
+
+    <style name="SnackBarButtonDark" parent="@style/Widget.MaterialComponents.Button.TextButton.Snackbar">
+        <item name="android:textColor">@color/snackBarButtonColor</item>
     </style>
 </resources>


### PR DESCRIPTION
- Disable flinging and reduce swipe threshold for station lists
- Removal from favourites now shows undo snackbar in most cases
- Increase undo snackbars duration to 6 seconds

@Vrihub this should fix all you troubles with removal from favourites.

<strike>I also want to fix snackbar theming in dark mode.</strike> Done