### PR TITLE
Fix wrong string values for giving_up_resume

### DIFF
--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -234,7 +234,7 @@
     <string name="error_caching_stream">Problema al «cachear» la emisión</string>
     <string name="error_play_stream">No se puede reproducir la emisión</string>
     <string name="error_stream_reconnect_timeout">No se puede volver a conectar a la transmisión: tiempo de espera agotado</string>
-    <string name="giving_up_resume">Intento de continuar la retransmisión ignorado</string>
+    <string name="giving_up_resume">Intento de continuar la retransmisión abandonado</string>
 
     <string name="error_record_needs_write">Necesito permisos de escritura para grabar</string>
     <string name="error_grant_audiofocus">La solicitud de enfoque de audio no fue otorgada por el sistema</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -189,7 +189,7 @@
     <string name="error_caching_stream">Problem z buforowaniem strumienia</string>
     <string name="error_play_stream">Nie można odtwarzać strumienia</string>
     <string name="error_stream_reconnect_timeout">Nie można ponownie połączyć się ze strumieniem: przekroczenie czasu oczekiwania</string>
-    <string name="giving_up_resume">Próba wznowienia odtwarzania została zignorowana</string>
+    <string name="giving_up_resume">Próba wznowienia odtwarzania została zaniechana</string>
 
     <string name="error_record_needs_write">Potrzebujesz uprawnień do zapisu dla nagrywania</string>
     <string name="error_grant_audiofocus">Żądanie dla audio focus nie zostało przyznane przez system</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -235,7 +235,7 @@
     <string name="error_play_stream">Unable to play stream</string>
     <string name="error_stream_reconnect_timeout">Unable to reconnect to the stream: timeout</string>
     <string name="warning_no_network_trying_resume">No network connection. Trying to resume when connection is back.</string>
-    <string name="giving_up_resume">Attempt to resume playback ignored</string>
+    <string name="giving_up_resume">Giving up attempt to resume playback</string>
 
     <string name="error_record_needs_write">Need write permission for recording</string>
     <string name="error_grant_audiofocus">Request for audio focus was not granted by the system</string>


### PR DESCRIPTION
This bug was already introduced in 4703dce0f1657c7a803cb943acf0db0a772f7199 and had often confused me.

I don't know if Chinese, Danish and Indonesian are also affected.
