### PR TITLE
Fix bottom sheet positioning on Android Q

### DIFF
--- a/app/src/main/res/layout/layout_player_bottom_sheet.xml
+++ b/app/src/main/res/layout/layout_player_bottom_sheet.xml
@@ -6,6 +6,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:translationZ="10dp"
+    app:gestureInsetBottomIgnored="true"
     app:behavior_hideable="false"
     app:behavior_peekHeight="?android:attr/actionBarSize"
     app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">


### PR DESCRIPTION
Android Q introduced gesture navigation which in combination with
edge-to-edge app mode may cause gestures conflict with bottom sheet.

To fix this in new release of material components
bottom sheet automatically adjust position based on system defined
insets. However it doesn't know where bottom sheet actually is
and if the app supports edge-to-edge mode.

Since we don't support edge-to-edge mode - we could just disable
this new feature of bottom sheet.

Closes: #798

See:
- https://github.com/material-components/material-components-android/commit/4e28d9c9162d8f4c73dfa1b397f52ef5e32ed726 
- https://medium.com/androiddevelopers/gesture-navigation-handling-visual-overlaps-4aed565c134c
- https://medium.com/androiddevelopers/gesture-navigation-going-edge-to-edge-812f62e4e83e


@morckx Could you test on real Android 10 device without bottom bar in RadioDroid and with enabled gesture navigation? 