### PR TITLE
Remove add to favorites menu entry in full player

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/FragmentPlayerSmall.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/FragmentPlayerSmall.java
@@ -284,14 +284,6 @@ public class FragmentPlayerSmall extends Fragment {
                     StationActions.share(requireContext(), currentStation);
                     break;
                 }
-                case R.id.action_bookmark: {
-                    if (stationIsInFavourites) {
-                        StationActions.removeFromFavourites(requireContext(), getView(), currentStation);
-                    } else {
-                        StationActions.markAsFavourite(requireContext(), currentStation);
-                    }
-                    break;
-                }
                 case R.id.action_set_alarm: {
                     StationActions.setAsAlarm(requireActivity(), currentStation);
                     break;

--- a/app/src/main/res/menu/menu_player.xml
+++ b/app/src/main/res/menu/menu_player.xml
@@ -7,15 +7,6 @@
         android:icon="@drawable/ic_store_black_24dp"
         android:title="@string/action_homepage" />
     <item
-        android:id="@+id/action_bookmark"
-        android:icon="@drawable/ic_star_border_black_24dp"
-        android:title="@string/detail_star" />
-    <!--<item-->
-    <!--android:id="@+id/action_unstar"-->
-    <!--android:icon="@drawable/ic_star_black_24dp"-->
-    <!--android:title="@string/detail_unstar"-->
-    <!--app:showAsAction="ifRoom"/>-->
-    <item
         android:id="@+id/action_set_alarm"
         android:icon="@drawable/ic_query_builder_black_24dp"
         android:title="@string/action_alarm" />


### PR DESCRIPTION
Fixes #799

The menu entry is not adapted correctly to "remove from favorites" if a
station is already bookmarked and it is obsolete here anyway, having
already the large star button at the bottom for (un-)bookmarking.