### PR TITLE
Add github action to perform CI tests on pushes and pull requests

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,0 +1,28 @@
+name: RadioDroid CI
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - master
+  # Also trigger on page_build, as well as release created events
+  page_build:
+  release:
+    types: # This configuration does not affect the page_build event above
+      - created
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Tests
+      run: bash ./gradlew test --stacktrace


### PR DESCRIPTION
I don't know if this is already perfectly configured, but it should already help avoiding issues like #810 as pull requests will be automatically checked and marked accordingly.