### PR TITLE
Share station links as text

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/station/StationActions.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/station/StationActions.java
@@ -188,14 +188,14 @@ public class StationActions {
                 LocalBroadcastManager.getInstance(ctx).sendBroadcast(new Intent(ActivityMain.ACTION_HIDE_LOADING));
 
                 if (result != null) {
-                    Intent share = new Intent(Intent.ACTION_VIEW);
-                    share.setDataAndType(Uri.parse(result), "audio/*");
+                    Intent share = new Intent(Intent.ACTION_SEND);
+                    share.setType("text/plain");
+                    share.putExtra(Intent.EXTRA_SUBJECT, station.Name);
+                    share.putExtra(Intent.EXTRA_TEXT, result);
                     String title = ctx.getResources().getString(R.string.share_action);
                     Intent chooser = Intent.createChooser(share, title);
 
-                    if (share.resolveActivity(ctx.getPackageManager()) != null) {
-                        ctx.startActivity(chooser);
-                    }
+                    ctx.startActivity(chooser);
                 } else {
                     Toast toast = Toast.makeText(ctx.getApplicationContext(), ctx.getResources().getText(R.string.error_station_load), Toast.LENGTH_SHORT);
                     toast.show();


### PR DESCRIPTION
This allows for sharing links also via messengers, e-mail clients, etc.

On newer Androids the sharing also with audio players, such as VLC,
seems improved and there is an option to copy links to the clipboard.

Fixes #39 and fixes #812 (see also #809)

<img width="256px" src="https://user-images.githubusercontent.com/1309388/81469677-a4b43300-91e6-11ea-9ab8-9c1546ac68e7.png"/>
