### PR TITLE
Re-run CI tests on open PRs when master changed

### DIFF
--- a/.github/workflows/re-run-pull-request-github-actions.yml
+++ b/.github/workflows/re-run-pull-request-github-actions.yml
@@ -1,0 +1,65 @@
+name: Re-run CI tests on open PRs
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  re-run-github-actions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: (GET-&-PUT Github API) Push empty commit to PR branch
+        uses: actions/github-script@0.2.0
+        with:
+          github-token: ${{secrets.PAT}}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const {data: pullRequests} = await github.pulls.list({
+              owner,
+              repo,
+              base: "master",
+              state: "open",
+            });
+        
+            for (pr of pullRequests) {
+              try {
+                let pullReq = {};
+                while (pullReq.mergeable === undefined || pullReq.mergeable === null) {
+                  pullReq = (
+                    await github.pulls.get({
+                      owner,
+                      repo,
+                      pull_number: pr.number,
+                    })
+                  ).data;
+                }
+                if(pullReq.mergeable === false) continue;
+
+                const {data: commitData} = await github.repos.getCommit({
+                  owner,
+                  repo,
+                  ref: pullReq.head.sha,
+                });
+
+                const {data: createdCommit} = await github.git.createCommit({
+                  owner,
+                  repo,
+                  message: "trigger github actions",
+                  tree: commitData.commit.tree.sha,
+                  parents: [commitData.sha],
+                  commiter: context.payload.pusher,
+                  author: context.payload.pusher,
+                });
+
+                await github.git.updateRef({
+                  owner,
+                  repo,
+                  ref: `heads/${pr.head.ref}`,
+                  sha: createdCommit.sha,
+                });
+              } catch (err) {
+                console.log(err);
+              }
+            }


### PR DESCRIPTION
This should run all CI tests on open pull requests whenever the master branch is updated.

@segler-alex : if you want to test or merge this, you first need to create a Personal Access Token here https://github.com/settings/tokens , if you haven't yet. 
Don't ask me about the necessary scopes. Apparently, I intuitively chose a sufficient superset, but I don't know if it is minimal.

Copy the token and add a new secret with the name _PAT_ here:
https://github.com/segler-alex/RadioDroid/settings/secrets and paste the token from the clipboard into the value field.