### PR TITLE
Fix choice of external audio players

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/players/PlayStationTask.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/PlayStationTask.java
@@ -60,7 +60,8 @@ public class PlayStationTask extends AsyncTask<Void, Void, String> {
     public static PlayStationTask playExternal(DataRadioStation stationToPlay, Context ctx) {
         return new PlayStationTask(stationToPlay, ctx, url -> {
             Intent share = new Intent(Intent.ACTION_VIEW);
-            share.setDataAndType(Uri.parse(url), "audio/*");
+            share.setType("audio/*");
+            share.setData(Uri.parse(url));
             ctx.startActivity(share);
         }, null);
     }


### PR DESCRIPTION
With this change, depending on the actual stream type, dedicated radio and audio stream players like VLC, XiiaLive, and Yatse are offered as external players. Without apparently only apps that handle urls in general.
```
share.setDataAndType(Uri.parse(url), "audio/*")
```
Overrides the MIME type that would ordinarily be inferred from the data.

This is not the case with:

```
share.setType("audio/*"); // redundant on some APIs
share.setData(Uri.parse(url));

```
See:
https://developer.android.com/reference/android/content/Intent#setDataAndType(android.net.Uri,%20java.lang.String)