### PR TITLE
Align station detail actions with those of the icon only popup menu

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -109,6 +109,7 @@ dependencies {
     implementation 'com.google.android.exoplayer:exoplayer-hls:2.11.4'
     implementation 'com.google.android.exoplayer:exoplayer:2.11.4'
     implementation "com.mikepenz:iconics-core:4.0.2"
+    implementation "com.mikepenz:iconics-views:4.0.2"
     implementation 'com.mikepenz:google-material-typeface:3.0.1.4.original-kotlin@aar'
     implementation 'com.mikepenz:community-material-typeface:3.5.95.1-kotlin@aar'
     implementation 'com.github.rustamg:file-dialogs:1.0'

--- a/app/src/main/java/net/programmierecke/radiodroid2/station/ItemAdapterStation.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/station/ItemAdapterStation.java
@@ -16,7 +16,6 @@ import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 
-import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
 import androidx.core.content.ContextCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
@@ -31,8 +30,15 @@ import android.view.ViewGroup;
 import android.view.ViewStub;
 import android.widget.*;
 
+import com.mikepenz.iconics.IconicsDrawable;
+import com.mikepenz.iconics.IconicsSize;
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial;
+import com.mikepenz.iconics.view.IconicsImageButton;
+
 import net.programmierecke.radiodroid2.*;
 import net.programmierecke.radiodroid2.interfaces.IAdapterRefreshable;
+import net.programmierecke.radiodroid2.players.PlayStationTask;
+import net.programmierecke.radiodroid2.players.selector.PlayerType;
 import net.programmierecke.radiodroid2.utils.RecyclerItemMoveAndSwipeHelper;
 import net.programmierecke.radiodroid2.service.PlayerService;
 import net.programmierecke.radiodroid2.service.PlayerServiceUtil;
@@ -112,13 +118,14 @@ public class ItemAdapterStation
 
         View viewDetails;
         ViewStub stubDetails;
-        ImageButton buttonStationLinks;
+        IconicsImageButton buttonVisitWebsite;
         ImageButton buttonBookmark;
+        ImageButton buttonShare;
         ImageView imageTrend;
         ImageButton buttonAddAlarm;
         TagsView viewTags;
         ImageButton buttonCreateShortcut;
-        ImageButton buttonPlayInRadioDroid;
+        ImageButton buttonPlayInternalOrExternal;
 
         StationViewHolder(View itemView) {
             super(itemView);
@@ -359,49 +366,30 @@ public class ItemAdapterStation
             holder.viewDetails = holder.stubDetails == null ? holder.viewDetails : holder.stubDetails.inflate();
             holder.stubDetails = null;
             holder.viewTags = (TagsView) holder.viewDetails.findViewById(R.id.viewTags);
-            holder.buttonStationLinks = holder.viewDetails.findViewById(R.id.buttonStationWebLink);
+            holder.buttonVisitWebsite = holder.viewDetails.findViewById(R.id.buttonVisitWebsite);
+            holder.buttonShare = holder.viewDetails.findViewById(R.id.buttonShare);
             holder.buttonBookmark = holder.viewDetails.findViewById(R.id.buttonBookmark);
             holder.buttonAddAlarm = holder.viewDetails.findViewById(R.id.buttonAddAlarm);
             holder.buttonCreateShortcut = holder.viewDetails.findViewById(R.id.buttonCreateShortcut);
-            holder.buttonPlayInRadioDroid = holder.viewDetails.findViewById(R.id.buttonPlayInRadioDroid);
+            holder.buttonPlayInternalOrExternal = holder.viewDetails.findViewById(R.id.buttonPlayInRadioDroid);
 
-//            holder.buttonShare.setOnClickListener(new View.OnClickListener() {
-//                @Override
-//                public void onClick(View view) {
-//                    StationActions.share(getContext(), station);
-//                }
-//            });
-
-            holder.buttonStationLinks.setOnClickListener(new View.OnClickListener() {
+            holder.buttonVisitWebsite.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View view) {
-                    StationActions.showWebLinks(activity, station);
+                    StationActions.openStationHomeUrl(activity, station);
                 }
             });
 
+            holder.buttonShare.setOnClickListener(view -> StationActions.share(activity, station));
+
             if (favouriteManager.has(station.StationUuid)) {
-                holder.buttonBookmark.setImageResource(R.drawable.ic_star_black_24dp);
-                holder.buttonBookmark.setContentDescription(getContext().getApplicationContext().getString(R.string.detail_unstar));
-                holder.buttonBookmark.setOnClickListener(new View.OnClickListener() {
-                    @Override
-                    public void onClick(View view) {
-                        StationActions.removeFromFavourites(getContext(), view, station);
-
-                        int position = holder.getAdapterPosition();
-                        notifyItemChanged(position);
-                    }
-                });
+                // favorite stations should only be removed in the favorites view
+                holder.buttonBookmark.setVisibility(View.GONE);
             } else {
-                holder.buttonBookmark.setImageResource(R.drawable.ic_star_border_black_24dp);
-                holder.buttonBookmark.setContentDescription(getContext().getApplicationContext().getString(R.string.detail_star));
-                holder.buttonBookmark.setOnClickListener(new View.OnClickListener() {
-                    @Override
-                    public void onClick(View view) {
-                        StationActions.markAsFavourite(getContext(), station);
-
-                        int position = holder.getAdapterPosition();
-                        notifyItemChanged(position);
-                    }
+                holder.buttonShare.setOnClickListener(view -> {
+                    StationActions.markAsFavourite(getContext(), station);
+                    int position1 = holder.getAdapterPosition();
+                    notifyItemChanged(position1);
                 });
             }
 
@@ -425,11 +413,17 @@ public class ItemAdapterStation
                 }
             });
 
-            // TODO: Maybe show only when external player is enabled?
-            holder.buttonPlayInRadioDroid.setOnClickListener(v -> {
-                StationActions.playInRadioDroid(getContext(), station);
-            });
-
+            if (prefs.getBoolean("play_external", false)) {
+                holder.buttonPlayInternalOrExternal.setOnClickListener(v -> {
+                    StationActions.playInRadioDroid(getContext(), station);
+                });
+            } else {
+                Context context = getContext();
+                holder.buttonPlayInternalOrExternal.setContentDescription(getContext().getString(R.string.detail_play_in_external_player));
+                holder.buttonPlayInternalOrExternal.setImageDrawable(new IconicsDrawable(getContext(), CommunityMaterial.Icon2.cmd_play_box_outline).size(IconicsSize.dp(24)));
+                holder.buttonPlayInternalOrExternal.setOnClickListener(v -> Utils.playAndWarnIfMetered((RadioDroidApp) context.getApplicationContext(), station,
+                        PlayerType.EXTERNAL, () -> PlayStationTask.playExternal(station, context).execute()));
+            }
             String[] tags = station.TagsAll.split(",");
             holder.viewTags.setTags(Arrays.asList(tags));
             holder.viewTags.setTagSelectionCallback(tagSelectionCallback);

--- a/app/src/main/res/layout/stub_list_item_station_details.xml
+++ b/app/src/main/res/layout/stub_list_item_station_details.xml
@@ -25,25 +25,27 @@
             android:layout_height="wrap_content"
             android:orientation="horizontal">
 
-        <ImageButton
-                android:id="@+id/buttonStationWebLink"
+        <com.mikepenz.iconics.view.IconicsImageButton
+                android:id="@+id/buttonVisitWebsite"
                 style="@style/IconButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:contentDescription="@string/detail_weblink"
+                android:contentDescription="@string/detail_visit_website"
                 android:background="?attr/selectableItemBackgroundBorderless"
                 android:tint="?attr/iconsInItemBackgroundColor"
-                app:srcCompat="@drawable/ic_store_black_24dp"/>
+                app:iiv_icon="gmd-home"
+                app:iiv_padding="2dp"
+                app:iiv_size="24dp"/>
 
-        <!--<ImageButton-->
-                <!--android:id="@+id/buttonShare"-->
-                <!--style="@style/IconButton"-->
-                <!--android:layout_width="wrap_content"-->
-                <!--android:layout_height="wrap_content"-->
-                <!--android:contentDescription="@string/detail_share"-->
-                <!--android:background="?attr/selectableItemBackgroundBorderless"-->
-                <!--android:tint="?attr/iconsInItemBackgroundColor"-->
-                <!--app:srcCompat="@drawable/ic_share_24dp" />-->
+        <ImageButton
+                android:id="@+id/buttonShare"
+                style="@style/IconButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:contentDescription="@string/detail_share"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:tint="?attr/iconsInItemBackgroundColor"
+                app:srcCompat="@drawable/ic_share_24dp" />
 
         <ImageButton
                 android:id="@+id/buttonBookmark"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="detail_create_shortcut">Add to home screen</string>
     <string name="detail_language">Language</string>
     <string name="detail_weblink">Weblink</string>
+    <string name="detail_visit_website">@string/action_station_visit_website</string>
     <string name="detail_play">Play</string>
     <string name="detail_pause">Pause</string>
     <string name="detail_stop">Stop</string>
@@ -61,6 +62,7 @@
     <string name="about_version">Version: %1$s</string>
     <string name="detail_star">Add to favorites</string>
     <string name="detail_unstar">Delete from favorites</string>
+    <string name="detail_play_in_external_player">@string/action_play_in_external</string>
     <string name="progress_loading">Loading...</string>
 
     <string name="sleep_timer" formatted="true">Sleep timer: %1$02d:%2$02d</string>


### PR DESCRIPTION

![Screenshot_1589634914](https://user-images.githubusercontent.com/1309388/82120801-f7629180-9788-11ea-9099-d5178c9492ff.png)

Note that you cannot delete a station from the favorites via the station detail buttons anymore. For this our nice swipe to delete in the favorites view should be used. I think, all in all the pros outweigh the cons here.

-------

![Screenshot_1589634863](https://user-images.githubusercontent.com/1309388/82120802-f7fb2800-9788-11ea-8491-62ae81af1b1f.png)

Starring/adding to favourites is of course still possible. In addition, note the button for external player that is shown when internal player is configured:
