### PR TITLE
Fix false negatives in hls stream detection

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/Utils.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/Utils.java
@@ -56,6 +56,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
@@ -317,6 +319,11 @@ public class Utils {
                     PlayerServiceUtil.setStation(station1);
                     PlayerServiceUtil.warnAboutMeteredConnection(playerType1);
                 });
+    }
+
+    public static boolean urlIndicatesHlsStream(String streamUrl) {
+        final Pattern p = Pattern.compile(".*\\.m3u8([#?\\s].*)?$");
+        return p.matcher(streamUrl).matches();
     }
 
     public interface MeteredWarningCallback {

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/ExoPlayerWrapper.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/ExoPlayerWrapper.java
@@ -182,7 +182,7 @@ public class ExoPlayerWrapper implements PlayerWrapper, IcyDataSource.IcyDataSou
             playerThreadHandler = new Handler(Looper.getMainLooper());
         }
 
-        isHls = streamUrl.endsWith(".m3u8");
+        isHls = Utils.urlIndicatesHlsStream(streamUrl);
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext());
         final int retryTimeout = prefs.getInt("settings_retry_timeout", 10);

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/mediaplayer/MediaPlayerWrapper.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/mediaplayer/MediaPlayerWrapper.java
@@ -10,6 +10,7 @@ import androidx.annotation.NonNull;
 
 import net.programmierecke.radiodroid2.BuildConfig;
 import net.programmierecke.radiodroid2.R;
+import net.programmierecke.radiodroid2.Utils;
 import net.programmierecke.radiodroid2.players.PlayState;
 import net.programmierecke.radiodroid2.station.live.ShoutcastInfo;
 import net.programmierecke.radiodroid2.station.live.StreamLiveInfo;
@@ -59,7 +60,7 @@ public class MediaPlayerWrapper implements PlayerWrapper, StreamProxyListener {
 
         Log.v(TAG, "Stream url:" + streamUrl);
 
-        isHls = streamUrl.endsWith(".m3u8");
+        isHls = Utils.urlIndicatesHlsStream(streamUrl);
 
         if (!isHls) {
             if (proxy != null) {

--- a/app/src/test/java/net/programmierecke/radiodroid2/UtilsTest.kt
+++ b/app/src/test/java/net/programmierecke/radiodroid2/UtilsTest.kt
@@ -1,0 +1,22 @@
+package net.programmierecke.radiodroid2
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+
+internal class UtilsTest {
+    @Test
+    fun testUrlIndicatesHlsStream() {
+        assert(Utils.urlIndicatesHlsStream("http://www.example.org/playlist.m3u8"))
+        assert(Utils.urlIndicatesHlsStream("http://www.example.org/playlist.m3u8 # cool"))
+        assert(Utils.urlIndicatesHlsStream("http://www.example.org/playlist.m3u8\n"))
+        assert(Utils.urlIndicatesHlsStream("https://stream.revma.ihrhls.com/zc5260/hls.m3u8?streamid=5260"))
+        assert(Utils.urlIndicatesHlsStream("http://www.example.org/playlist.m3u8?bitrate=256&z=43"))
+        assert(Utils.urlIndicatesHlsStream("http://www.example.org/playlist.m3u8#0100"))
+        assert(Utils.urlIndicatesHlsStream("http://www.example.org/playlist.m3u8#START"))
+        assert(Utils.urlIndicatesHlsStream("http://www.example.org/m3u8playlist.m3u8"))
+
+        assertFalse(Utils.urlIndicatesHlsStream("http://www.example.org/no.m3u8.m3u"))
+        assertFalse(Utils.urlIndicatesHlsStream("http://www.example.org/playlist.m3u85"))
+        assertFalse(Utils.urlIndicatesHlsStream("http://www.example.org/playlist.m3united"))
+    }
+}


### PR DESCRIPTION
Fixes #833

Some streams have a query after the path, like:

https://stream.revma.ihrhls.com/zc5260/hls.m3u8?streamid=5260

In the long run, we should probably have a more thorough detection or try switching if ExoPlayer can't detect the encoding, but for now this should work.
