### PR TITLE
Remove redundant full expoplayer library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -107,7 +107,6 @@ dependencies {
     implementation 'jp.wasabeef:picasso-transformations:2.2.1'
     implementation 'com.google.android.exoplayer:exoplayer-core:2.11.4'
     implementation 'com.google.android.exoplayer:exoplayer-hls:2.11.4'
-    implementation 'com.google.android.exoplayer:exoplayer:2.11.4'
     implementation "com.mikepenz:iconics-core:4.0.2"
     implementation "com.mikepenz:iconics-views:4.0.2"
     implementation 'com.mikepenz:google-material-typeface:3.0.1.4.original-kotlin@aar'


### PR DESCRIPTION
Shrinks free debug build by almost 10%.