### PR TITLE
WIP: added startup settings switch to not request IcyMetadata

### DIFF
--- a/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/ExoPlayerWrapper.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/ExoPlayerWrapper.java
@@ -187,7 +187,7 @@ public class ExoPlayerWrapper implements PlayerWrapper, IcyDataSource.IcyDataSou
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext());
         final int retryTimeout = prefs.getInt("settings_retry_timeout", 10);
         final int retryDelay = prefs.getInt("settings_retry_delay", 100);
-	final boolean requestIcyMetadata = prefs.getBoolean("settings_request_icymetadata", false);
+	final boolean requestIcyMetadata = prefs.getBoolean("request_icymetadata", false);
 
         DataSource.Factory dataSourceFactory = new RadioDataSourceFactory(httpClient, bandwidthMeter, this, requestIcyMetadata);
         // Produces Extractor instances for parsing the media data.

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/ExoPlayerWrapper.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/ExoPlayerWrapper.java
@@ -187,8 +187,9 @@ public class ExoPlayerWrapper implements PlayerWrapper, IcyDataSource.IcyDataSou
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext());
         final int retryTimeout = prefs.getInt("settings_retry_timeout", 10);
         final int retryDelay = prefs.getInt("settings_retry_delay", 100);
+	final boolean requestIcyMetadata = prefs.getBoolean("settings_request_icymetadata", false);
 
-        DataSource.Factory dataSourceFactory = new RadioDataSourceFactory(httpClient, bandwidthMeter, this, retryTimeout, retryDelay);
+        DataSource.Factory dataSourceFactory = new RadioDataSourceFactory(httpClient, bandwidthMeter, this, requestIcyMetadata);
         // Produces Extractor instances for parsing the media data.
         if (!isHls) {
             audioSource = new ProgressiveMediaSource.Factory(dataSourceFactory)

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/IcyDataSource.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/IcyDataSource.java
@@ -84,16 +84,19 @@ public class IcyDataSource implements HttpDataSource {
     int metadataBytesToSkip = 0;
     int remainingUntilMetadata = Integer.MAX_VALUE;
     private boolean opened;
+    private boolean requestIcyMetadata;
 
     ShoutcastInfo shoutcastInfo;
     private StreamLiveInfo streamLiveInfo;
 
     public IcyDataSource(@NonNull OkHttpClient httpClient,
                          @NonNull TransferListener listener,
-                         @NonNull IcyDataSourceListener dataSourceListener) {
+                         @NonNull IcyDataSourceListener dataSourceListener,
+			 boolean requestIcyMetadata) {
         this.httpClient = httpClient;
         this.transferListener = listener;
         this.dataSourceListener = dataSourceListener;
+        this.requestIcyMetadata = requestIcyMetadata;
     }
 
     @Override
@@ -105,8 +108,11 @@ public class IcyDataSource implements HttpDataSource {
         final boolean allowGzip = (dataSpec.flags & DataSpec.FLAG_ALLOW_GZIP) != 0;
 
         HttpUrl url = HttpUrl.parse(dataSpec.uri.toString());
-        Request.Builder builder = new Request.Builder().url(url)
-                .addHeader("Icy-MetaData", "1");
+        Request.Builder builder = new Request.Builder().url(url);
+
+	if (requestIcyMetadata) {
+                builder.addHeader("Icy-MetaData", "1");
+	}
 
         if (!allowGzip) {
             builder.addHeader("Accept-Encoding", "identity");

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/RadioDataSourceFactory.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/RadioDataSourceFactory.java
@@ -21,8 +21,6 @@ public class RadioDataSourceFactory implements DataSource.Factory {
         this.httpClient = httpClient;
         this.transferListener = transferListener;
         this.dataSourceListener = dataSourceListener;
-        this.retryTimeout = retryTimeout;
-        this.retryDelay = retryDelay;
     }
 
     @Override

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/RadioDataSourceFactory.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/exoplayer/RadioDataSourceFactory.java
@@ -12,14 +12,12 @@ public class RadioDataSourceFactory implements DataSource.Factory {
     private OkHttpClient httpClient;
     private final TransferListener transferListener;
     private IcyDataSource.IcyDataSourceListener dataSourceListener;
-    private long retryTimeout;
-    private long retryDelay;
+    private boolean requestIcyMetadata;
 
     public RadioDataSourceFactory(@NonNull OkHttpClient httpClient,
                                   @NonNull TransferListener transferListener,
                                   @NonNull IcyDataSource.IcyDataSourceListener dataSourceListener,
-                                  long retryTimeout,
-                                  long retryDelay) {
+                                  boolean requestIcyMetadata) {
         this.httpClient = httpClient;
         this.transferListener = transferListener;
         this.dataSourceListener = dataSourceListener;
@@ -29,6 +27,6 @@ public class RadioDataSourceFactory implements DataSource.Factory {
 
     @Override
     public DataSource createDataSource() {
-        return new IcyDataSource(httpClient, transferListener, dataSourceListener);
+        return new IcyDataSource(httpClient, transferListener, dataSourceListener, requestIcyMetadata);
     }
 }

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/mediaplayer/MediaPlayerWrapper.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/mediaplayer/MediaPlayerWrapper.java
@@ -1,12 +1,14 @@
 package net.programmierecke.radiodroid2.players.mediaplayer;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.media.AudioManager;
 import android.media.MediaPlayer;
 import android.os.Handler;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
+import androidx.preference.PreferenceManager;
 
 import net.programmierecke.radiodroid2.BuildConfig;
 import net.programmierecke.radiodroid2.R;
@@ -62,8 +64,8 @@ public class MediaPlayerWrapper implements PlayerWrapper, StreamProxyListener {
 
         isHls = Utils.urlIndicatesHlsStream(streamUrl);
 
-	SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(context);
-        boolean requestIcyMetadata = sharedPref.getBoolean("settings_request_icymetadata", false);
+	    SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(context);
+        final boolean requestIcyMetadata = sharedPref.getBoolean("request_icymetadata", false);
 
         if (!isHls) {
             if (proxy != null) {

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/mediaplayer/MediaPlayerWrapper.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/mediaplayer/MediaPlayerWrapper.java
@@ -62,13 +62,16 @@ public class MediaPlayerWrapper implements PlayerWrapper, StreamProxyListener {
 
         isHls = Utils.urlIndicatesHlsStream(streamUrl);
 
+	SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(context);
+        boolean requestIcyMetadata = sharedPref.getBoolean("settings_request_icymetadata", false);
+
         if (!isHls) {
             if (proxy != null) {
                 if (BuildConfig.DEBUG) Log.d(TAG, "stopping old proxy.");
                 stopProxy();
             }
 
-            proxy = new StreamProxy(httpClient, streamUrl, MediaPlayerWrapper.this);
+            proxy = new StreamProxy(httpClient, streamUrl, MediaPlayerWrapper.this, requestIcyMetadata);
         } else {
             stopProxy();
             onStreamCreated(streamUrl);

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/mediaplayer/StreamProxy.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/mediaplayer/StreamProxy.java
@@ -41,11 +41,13 @@ public class StreamProxy implements Recordable {
     private byte readBuffer[] = new byte[256 * 16];
     private volatile String localAddress = null;
     private boolean isStopped = false;
+    private boolean requestIcyMetadata;
 
-    public StreamProxy(OkHttpClient httpClient, String uri, StreamProxyListener callback) {
+    public StreamProxy(OkHttpClient httpClient, String uri, StreamProxyListener callback, bool requestIcyMetadata) {
         this.httpClient = httpClient;
         this.uri = uri;
         this.callback = callback;
+	this.requestIcyMetadata = requestIcyMetadata;
 
         createProxy();
     }
@@ -170,9 +172,13 @@ public class StreamProxy implements Recordable {
             final int port = proxyServer.getLocalPort();
             localAddress = String.format(Locale.US, "http://localhost:%d", port);
 
-            final Request request = new Request.Builder().url(uri)
-                    .addHeader("Icy-MetaData", "1")
-                    .build();
+            Request.Builder builder = new Request.Builder().url(uri);
+
+	    if (requestIcyMetadata) {
+                   builder.addHeader("Icy-MetaData", "1");
+	    }
+
+            final Request request = builder.built();
 
             while (!isStopped && retry > 0) {
                 ResponseBody responseBody = null;

--- a/app/src/main/java/net/programmierecke/radiodroid2/players/mediaplayer/StreamProxy.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/players/mediaplayer/StreamProxy.java
@@ -43,11 +43,11 @@ public class StreamProxy implements Recordable {
     private boolean isStopped = false;
     private boolean requestIcyMetadata;
 
-    public StreamProxy(OkHttpClient httpClient, String uri, StreamProxyListener callback, bool requestIcyMetadata) {
+    public StreamProxy(OkHttpClient httpClient, String uri, StreamProxyListener callback, boolean requestIcyMetadata) {
         this.httpClient = httpClient;
         this.uri = uri;
         this.callback = callback;
-	this.requestIcyMetadata = requestIcyMetadata;
+	    this.requestIcyMetadata = requestIcyMetadata;
 
         createProxy();
     }
@@ -178,7 +178,7 @@ public class StreamProxy implements Recordable {
                    builder.addHeader("Icy-MetaData", "1");
 	    }
 
-            final Request request = builder.built();
+            final Request request = builder.build();
 
             while (!isStopped && retry > 0) {
                 ResponseBody responseBody = null;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -117,6 +117,11 @@
     <string name="startup_show_history">Show history</string>
     <string name="startup_show_last_view">Last view</string>
 
+    <string name="request_icymetadata">Request IcyMetadata</string>
+    <string name="settings_request_icymetadata_off">do not request IcyMetadata</string>
+    <string name="settings_request_icymetadata_on">Request IcyMetadata</string>
+    <string name="settings_request_icymetadata">Request IcyMetadata</string>
+
     <string name="settings_load_icons">Show station icons</string>
     <string name="settings_load_icons_on">Icons will be downloaded</string>
     <string name="settings_load_icons_off">Icons will not be downloaded</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -60,7 +60,7 @@
 
         <CheckBoxPreference
             android:defaultValue="true"
-            android:key="settings_request_icymetadata"
+            android:key="request_icymetadata"
             android:summaryOff="@string/settings_request_icymetadata_off"
             android:summaryOn="@string/settings_request_icymetadata_on"
             android:title="@string/settings_request_icymetadata" />

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -58,6 +58,13 @@
             android:summaryOn="@string/settings_auto_play_on_startup_on"
             android:title="@string/settings_auto_play_on_startup" />
 
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="settings_request_icymetadata"
+            android:summaryOff="@string/settings_request_icymetadata_off"
+            android:summaryOn="@string/settings_request_icymetadata_on"
+            android:title="@string/settings_request_icymetadata" />
+
     </PreferenceScreen>
 
     <PreferenceScreen android:title="@string/settings_interaction"

--- a/app/src/test/java/net/programmierecke/radiodroid2/players/exoplayer/IcyDataSourceTest.java
+++ b/app/src/test/java/net/programmierecke/radiodroid2/players/exoplayer/IcyDataSourceTest.java
@@ -21,7 +21,7 @@ class IcyDataSourceTest {
 
     @BeforeAll
     public static void setup() {
-        icyDataSource = new IcyDataSource(new OkHttpClient(), new TestTransferListener(), new TestDataSourceListener());
+        icyDataSource = new IcyDataSource(new OkHttpClient(), new TestTransferListener(), new TestDataSourceListener(), true);
         icyDataSource.shoutcastInfo = new ShoutcastInfo();
         icyDataSource.shoutcastInfo.metadataOffset = 16000;
     }


### PR DESCRIPTION
Hi,
Thank you for creating/maintaining/providing the radiodroid app.

I have this station http://www.radio-browser.info/gui/#!/byname/rijnmond which I listen to at night when ... not sleeping.
Most of the time the non-stop music night program has glitches every few minutes, as if metadata is played as audio (...).
For the sake of being able to rule out that this is indeed metadata, I created a startup switch to disable IcyMetadata.
Default behavior of this switch is to do request IcyMetadata, as was the case without this new option.

If you agree with this additional option, then please pull this change.
If not and/or additional changes are required, please let me know.

As my java knowledge is a bit rusty, kotlin completely new for me and never worked on an android app, please review this pull request carefully ;)