### PR TITLE
Fix espresso tests failure on CI

### DIFF
--- a/.github/workflows/android-instrumented-tests-ci.yml
+++ b/.github/workflows/android-instrumented-tests-ci.yml
@@ -20,9 +20,9 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      - uses: malinskiy/action-android/install-sdk@release/0.0.7
+      - uses: malinskiy/action-android/install-sdk@release/0.1.0
       - name: Instrumented tests
-        uses: malinskiy/action-android/emulator-run-cmd@release/0.0.7
+        uses: malinskiy/action-android/emulator-run-cmd@release/0.1.0
         timeout-minutes: 35
         with:
           cmd: ./gradlew connectedFreeDebugAndroidTest

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -176,11 +176,13 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.3.0'
-    androidTestImplementation 'androidx.test:runner:1.3.1-alpha02'
-    androidTestImplementation 'androidx.test:rules:1.3.1-alpha02'
+    // Keep this versions 1.3.0 until bumping it won't break building of AndroidTest
+    androidTestImplementation 'androidx.test:runner:1.3.0'
+    androidTestImplementation 'androidx.test:rules:1.3.0'
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
 
-    androidTestImplementation("com.squareup.okhttp3:mockwebserver:4.9.0")
+    //noinspection GradleDependency
+    androidTestImplementation("com.squareup.okhttp3:mockwebserver:3.12.6")
     androidTestImplementation("com.github.YarikSOffice:lingver:1.2.1") {
         exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-jdk7'
     }

--- a/app/src/androidTest/java/net/programmierecke/radiodroid2/tests/UILangTest.java
+++ b/app/src/androidTest/java/net/programmierecke/radiodroid2/tests/UILangTest.java
@@ -12,7 +12,7 @@ import com.yariksoffice.lingver.Lingver;
 
 import net.programmierecke.radiodroid2.ActivityMain;
 import net.programmierecke.radiodroid2.R;
-import net.programmierecke.radiodroid2.test.BuildConfig;
+import net.programmierecke.radiodroid2.BuildConfig;
 import net.programmierecke.radiodroid2.tests.utils.TestUtils;
 import net.programmierecke.radiodroid2.tests.utils.ViewPagerIdlingResource;
 


### PR DESCRIPTION
1) Recently instrumented CI started to fail with:
 Error: Unable to process command '::set-env name=ANDROID_HOME,::/Users/runner/android-sdk' successfully.

2) Bumping of androidx.test:runner androidx.test:rules resulted in an error:
 AAPT: error: attribute android:forceQueryable not found.

3) .test.BuildConfig doesn't contain configs set in gradle

4) Starting of the instrumented app stucked somewhere after a bump of
   com.squareup.okhttp3:mockwebserver for unknown reason, revert it for
   now.