### PR TITLE
Android TV: show starred stations as a home screen channel

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -135,6 +135,7 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation 'androidx.tvprovider:tvprovider:1.0.0'
 
     // Keep OkHttp 3.12.X to support Android 4.X, see https://developer.squareup.com/blog/okhttp-3-13-requires-android-5
     //noinspection GradleDependency

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,9 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="com.android.providers.tv.permission.WRITE_EPG_DATA" />
+
+    <uses-sdk tools:overrideLibrary="androidx.tvprovider"/>
 
     <application
         android:banner="@mipmap/ic_banner"

--- a/app/src/main/java/net/programmierecke/radiodroid2/RadioDroidApp.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/RadioDroidApp.java
@@ -1,6 +1,8 @@
 package net.programmierecke.radiodroid2;
 
+import android.app.UiModeManager;
 import android.content.SharedPreferences;
+import android.content.res.Configuration;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -17,6 +19,7 @@ import net.programmierecke.radiodroid2.players.mpd.MPDClient;
 import net.programmierecke.radiodroid2.station.live.metadata.TrackMetadataSearcher;
 import net.programmierecke.radiodroid2.proxy.ProxySettings;
 import net.programmierecke.radiodroid2.recording.RecordingsManager;
+import net.programmierecke.radiodroid2.utils.TvChannelManager;
 
 import java.io.File;
 import java.io.IOException;
@@ -35,6 +38,7 @@ public class RadioDroidApp extends MultiDexApplication {
     private FavouriteManager favouriteManager;
     private RecordingsManager recordingsManager;
     private RadioAlarmManager alarmManager;
+    private TvChannelManager tvChannelManager;
 
     private TrackHistoryRepository trackHistoryRepository;
 
@@ -91,6 +95,12 @@ public class RadioDroidApp extends MultiDexApplication {
         favouriteManager = new FavouriteManager(this);
         recordingsManager = new RecordingsManager();
         alarmManager = new RadioAlarmManager(this);
+
+        UiModeManager uiModeManager = (UiModeManager) getSystemService(UI_MODE_SERVICE);
+        if (uiModeManager.getCurrentModeType() == Configuration.UI_MODE_TYPE_TELEVISION) {
+            tvChannelManager = new TvChannelManager(this);
+            favouriteManager.addObserver(tvChannelManager);
+        }
 
         trackHistoryRepository = new TrackHistoryRepository(this);
 

--- a/app/src/main/java/net/programmierecke/radiodroid2/utils/TvChannelManager.kt
+++ b/app/src/main/java/net/programmierecke/radiodroid2/utils/TvChannelManager.kt
@@ -1,0 +1,138 @@
+package net.programmierecke.radiodroid2.utils
+
+import android.annotation.SuppressLint
+import android.content.Intent
+import android.database.Cursor
+import android.os.Build
+import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.appcompat.content.res.AppCompatResources
+import androidx.core.graphics.drawable.toBitmap
+import androidx.core.net.toUri
+import androidx.tvprovider.media.tv.*
+import net.programmierecke.radiodroid2.ActivityMain
+import net.programmierecke.radiodroid2.R
+import net.programmierecke.radiodroid2.RadioDroidApp
+import net.programmierecke.radiodroid2.service.MediaSessionCallback
+import java.io.IOException
+import java.util.*
+
+private const val INVALID_CONTENT_ID: Long = -1
+
+fun <T : BaseProgram> Cursor.asSequence(fromCursor: (Cursor) -> T): Sequence<T> {
+    moveToFirst()
+    return generateSequence {
+        if (this.isAfterLast) {
+            close()
+            null
+        } else {
+            val next = fromCursor(this)
+            moveToNext()
+            next
+        }
+    }
+}
+
+@SuppressLint("RestrictedApi")
+class TvChannelManager(val app: RadioDroidApp) : Observer {
+    private val helper = PreviewChannelHelper(app)
+    private var channelId = INVALID_CONTENT_ID
+
+    init {
+        if (Build.VERSION.SDK_INT >= 26) {
+            channelId = helper.allChannels.firstOrNull()?.id ?: createDefaultChannel()
+        }
+    }
+
+    private fun createDefaultChannel(): Long = try {
+        val channel = with(PreviewChannel.Builder()) {
+            setDisplayName(app.getString(R.string.app_name))
+            setDescription(app.getString(R.string.app_name))
+            setAppLinkIntent(Intent(app, ActivityMain::class.java))
+            AppCompatResources.getDrawable(app, R.drawable.ic_launcher)?.toBitmap()?.also { logo ->
+                setLogo(logo)
+            }
+            build()
+        }
+        helper.publishChannel(channel)
+    } catch (e: IOException) {
+        Log.e(TAG, "Failed to create a channel", e)
+        INVALID_CONTENT_ID
+    }
+
+    @RequiresApi(26)
+    private fun getPreviewPrograms(): Sequence<PreviewProgram> = try {
+        val cursor = app.contentResolver.query(
+                TvContractCompat.PreviewPrograms.CONTENT_URI,
+                PreviewProgram.PROJECTION,
+                null,
+                null,
+                null)
+        cursor?.asSequence {
+            PreviewProgram.fromCursor(it)
+        } ?: emptySequence()
+    } catch (e: IllegalArgumentException) {
+        emptySequence()
+    }
+
+    @SuppressLint("NewApi")
+    private fun publishStarred() {
+        if (channelId == INVALID_CONTENT_ID) return
+
+        val starredPrograms = getPreviewPrograms().map {
+            Pair(it.contentId, it)
+        }.toMap().toMutableMap()
+
+        for (station in app.favouriteManager.list) {
+            val existingProgram = starredPrograms[station.StationUuid]
+            val programBuilder = existingProgram?.let {
+                PreviewProgram.Builder(it)
+            } ?: PreviewProgram.Builder()
+
+            val intent = Intent(
+                    MediaSessionCallback.ACTION_PLAY_STATION_BY_UUID,
+                    null,
+                    app,
+                    ActivityMain::class.java
+            ).putExtra(MediaSessionCallback.EXTRA_STATION_UUID, station.StationUuid)
+
+            val program = with(programBuilder) {
+                setChannelId(channelId)
+                setContentId(station.StationUuid)
+                setType(TvContractCompat.PreviewPrograms.TYPE_STATION)
+                setTitle(station.Name)
+                setPosterArtUri(station.IconUrl.toUri())
+                setLogoUri(station.IconUrl.toUri())
+                setIntent(intent)
+                setLive(true)
+                build()
+            }
+
+            if (existingProgram == null) {
+                Log.d(TAG, "Adding $station")
+                helper.publishPreviewProgram(program)
+            } else {
+                Log.d(TAG, "Updating $station")
+                helper.updatePreviewProgram(existingProgram.id, program)
+                starredPrograms.remove(existingProgram.contentId)
+            }
+        }
+
+        for (program in starredPrograms.values) {
+            Log.d(TAG, "Deleting programme $program")
+            helper.deletePreviewProgram(program.id)
+        }
+        if (app.favouriteManager.list.any()) {
+            Log.d(TAG, "Requesting channel to be browseable")
+            TvContractCompat.requestChannelBrowsable(app, channelId)
+        }
+    }
+
+    override fun update(p0: Observable?, p1: Any?) {
+        publishStarred()
+    }
+
+    companion object {
+        private val TAG = TvChannelManager::class.java.simpleName
+    }
+}


### PR DESCRIPTION
This merge request adds an Android TV feature making starred programmes available on the home screen.

![Home screen featuring a starred radio station](https://user-images.githubusercontent.com/309253/104644797-8d4f1300-56ae-11eb-9c5a-34229676e07a.png)

The channel is created as non-browseable by default since when a channel doesn’t have any programmes, it shows a button launching the application itself — probably not what a user wants if they never used the app and never starred any stations.

As a first station is starred, `TvChannelManager` requests the system to make the channel browseable. This works for the first channel the application creates *only*, which is why the channel is never removed — if we recreate a channel, it won’t be shown on the home screen and the user will have to make it visible manually.

The APIs this code uses are available since the API level 26 only, and the library wrapping them needs minimal SDK version 21; however, since we want to support API level 16, this needs to be overridden in the manifest.

I have verified and the app runs without any problems on Android 4.1 (API level 16).