### PR TITLE
Fix PlayerService destruction on orientation change

### DIFF
--- a/app/src/androidTest/java/net/programmierecke/radiodroid2/tests/UINotificationTests.java
+++ b/app/src/androidTest/java/net/programmierecke/radiodroid2/tests/UINotificationTests.java
@@ -1,8 +1,5 @@
 package net.programmierecke.radiodroid2.tests;
 
-import android.content.Context;
-import android.media.AudioManager;
-
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.espresso.ViewInteraction;
 import androidx.test.espresso.action.ViewActions;
@@ -33,13 +30,15 @@ import javax.annotation.Nonnull;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayingAtLeast;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static net.programmierecke.radiodroid2.tests.utils.TestUtils.expectNoNotification;
+import static net.programmierecke.radiodroid2.tests.utils.TestUtils.expectRunningNotification;
 import static org.hamcrest.core.AllOf.allOf;
 import static org.junit.Assert.assertNotNull;
 
 @LargeTest
 @RunWith(AndroidJUnit4.class)
-// UI notifications currently only work with API 26+
-@SdkSuppress(minSdkVersion = 26)
+// UI notifications currently only work with API 23+
+@SdkSuppress(minSdkVersion = 23)
 public class UINotificationTests {
 
     @Rule
@@ -101,8 +100,7 @@ public class UINotificationTests {
         UiDevice uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
         uiDevice.openNotification();
 
-        String expectedAppName = ApplicationProvider.getApplicationContext().getString(R.string.app_name);
-        uiDevice.wait(Until.hasObject(By.textStartsWith(expectedAppName)), 250);
+        expectRunningNotification(uiDevice);
         uiDevice.wait(Until.hasObject(By.desc(ApplicationProvider.getApplicationContext().getString(R.string.action_resume))), 250);
 
         UiObject2 resumeBtn = uiDevice.findObject(By.desc(ApplicationProvider.getApplicationContext().getString(R.string.action_resume)));
@@ -122,8 +120,7 @@ public class UINotificationTests {
         UiDevice uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
         uiDevice.openNotification();
 
-        String expectedAppName = ApplicationProvider.getApplicationContext().getString(R.string.app_name);
-        uiDevice.wait(Until.hasObject(By.textStartsWith(expectedAppName)), 250);
+        expectRunningNotification(uiDevice);
         uiDevice.wait(Until.hasObject(By.desc(ApplicationProvider.getApplicationContext().getString(R.string.action_pause))), 250);
 
         UiObject2 pauseBtn = uiDevice.findObject(By.desc(ApplicationProvider.getApplicationContext().getString(R.string.action_pause)));
@@ -143,8 +140,7 @@ public class UINotificationTests {
         UiDevice uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
         uiDevice.openNotification();
 
-        String expectedAppName = ApplicationProvider.getApplicationContext().getString(R.string.app_name);
-        uiDevice.wait(Until.hasObject(By.textStartsWith(expectedAppName)), 250);
+        expectRunningNotification(uiDevice);
         uiDevice.wait(Until.hasObject(By.desc(ApplicationProvider.getApplicationContext().getString(R.string.action_stop))), 250);
 
         UiObject2 stopBtn = uiDevice.findObject(By.desc(ApplicationProvider.getApplicationContext().getString(R.string.action_stop)));
@@ -152,18 +148,7 @@ public class UINotificationTests {
 
         stopBtn.click();
 
-        ConditionWatcher.waitForCondition(new ConditionWatcher.Condition() {
-            @Override
-            public boolean testCondition() {
-                return uiDevice.findObject(By.textStartsWith(expectedAppName)) == null;
-            }
-
-            @Nonnull
-            @Override
-            public String getDescription() {
-                return "Wait for notification to disappear";
-            }
-        }, ConditionWatcher.SHORT_WAIT_POLICY);
+        expectNoNotification(uiDevice);
 
         ConditionWatcher.waitForCondition(new IsMusicPlayingCondition(false), ConditionWatcher.SHORT_WAIT_POLICY);
     }

--- a/app/src/androidTest/java/net/programmierecke/radiodroid2/tests/utils/TestUtils.java
+++ b/app/src/androidTest/java/net/programmierecke/radiodroid2/tests/utils/TestUtils.java
@@ -4,15 +4,23 @@ import android.content.Context;
 import android.view.View;
 
 import androidx.recyclerview.widget.RecyclerView;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.espresso.UiController;
+import androidx.test.uiautomator.By;
+import androidx.test.uiautomator.UiDevice;
+import androidx.test.uiautomator.Until;
 
 import net.programmierecke.radiodroid2.BuildConfig;
 import net.programmierecke.radiodroid2.FavouriteManager;
 import net.programmierecke.radiodroid2.HistoryManager;
+import net.programmierecke.radiodroid2.R;
 import net.programmierecke.radiodroid2.RadioDroidApp;
 import net.programmierecke.radiodroid2.station.DataRadioStation;
+import net.programmierecke.radiodroid2.tests.utils.conditionwatcher.ConditionWatcher;
 
 import java.util.Objects;
+
+import javax.annotation.Nonnull;
 
 public class TestUtils {
 
@@ -102,5 +110,27 @@ public class TestUtils {
 
         recyclerView.scrollBy(scrollX, scrollY);
         uiController.loopMainThreadUntilIdle();
+    }
+
+    public static void expectRunningNotification(UiDevice uiDevice) {
+        String expectedAppName = ApplicationProvider.getApplicationContext().getString(R.string.app_name);
+        uiDevice.wait(Until.hasObject(By.textStartsWith(expectedAppName)), 250);
+    }
+
+    public static void expectNoNotification(UiDevice uiDevice) {
+        String expectedAppName = ApplicationProvider.getApplicationContext().getString(R.string.app_name);
+
+        ConditionWatcher.waitForCondition(new ConditionWatcher.Condition() {
+            @Override
+            public boolean testCondition() {
+                return uiDevice.findObject(By.textStartsWith(expectedAppName)) == null;
+            }
+
+            @Nonnull
+            @Override
+            public String getDescription() {
+                return "Wait for notification to disappear";
+            }
+        }, ConditionWatcher.SHORT_WAIT_POLICY);
     }
 }

--- a/app/src/main/aidl/net/programmierecke/radiodroid2/IPlayerService.aidl
+++ b/app/src/main/aidl/net/programmierecke/radiodroid2/IPlayerService.aidl
@@ -36,6 +36,7 @@ long getBufferedSeconds();
 long getLastPlayStartTime();
 boolean getIsHls();
 PauseReason getPauseReason();
+boolean isNotificationActive();
 
 void enableMPD(String hostname, int port);
 void disableMPD();

--- a/app/src/main/java/net/programmierecke/radiodroid2/ActivityMain.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/ActivityMain.java
@@ -169,7 +169,7 @@ public class ActivityMain extends AppCompatActivity implements SearchView.OnQuer
         final Toolbar myToolbar = findViewById(R.id.my_awesome_toolbar);
         setSupportActionBar(myToolbar);
 
-        PlayerServiceUtil.bind(this);
+        PlayerServiceUtil.startService(getApplicationContext());
 
         selectedMenuItem = sharedPref.getInt("last_selectedMenuItem", -1);
         instanceStateWasSaved = savedInstanceState != null;
@@ -448,7 +448,14 @@ public class ActivityMain extends AppCompatActivity implements SearchView.OnQuer
     @Override
     public void onDestroy() {
         super.onDestroy();
-        PlayerServiceUtil.unBind(this);
+
+        if (!PlayerServiceUtil.isNotificationActive()) {
+            /* If at this point if for whatever reason we have the service without a notification,
+             * we must shut it down because user doesn't have a way to interact with it.
+             * This is a safeguard since such service should have been destroyed in onPause()
+             */
+            PlayerServiceUtil.shutdownService();
+        }
     }
 
     @Override
@@ -530,7 +537,7 @@ public class ActivityMain extends AppCompatActivity implements SearchView.OnQuer
 
         setupBroadcastReceiver();
 
-        PlayerServiceUtil.bind(this);
+        PlayerServiceUtil.startService(getApplicationContext());
         CastHandler castHandler = ((RadioDroidApp) getApplication()).getCastHandler();
         castHandler.onResume();
         castHandler.setActivity(this);

--- a/app/src/main/java/net/programmierecke/radiodroid2/service/PlayerService.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/service/PlayerService.java
@@ -8,7 +8,6 @@ import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
-import android.app.Service;
 import android.bluetooth.BluetoothA2dp;
 import android.bluetooth.BluetoothHeadset;
 import android.content.Context;
@@ -334,6 +333,11 @@ public class PlayerService extends JobIntentService implements RadioPlayer.Playe
         public void warnAboutMeteredConnection(PlayerType playerType) throws RemoteException {
             PlayerService.this.warnAboutMeteredConnection(playerType);
         }
+
+        @Override
+        public boolean isNotificationActive() throws RemoteException {
+            return PlayerService.this.notificationIsActive;
+        }
     };
 
     private MediaSessionCompat.Callback mediaSessionCallback = null;
@@ -500,7 +504,7 @@ public class PlayerService extends JobIntentService implements RadioPlayer.Playe
     public int onStartCommand(Intent intent, int flags, int startId) {
         // Service could be started by external forces, e.g. when we had the last media session
         // and user presses play/pause media button.
-        PlayerServiceUtil.bind(itsContext.getApplicationContext());
+        PlayerServiceUtil.bindService(itsContext.getApplicationContext());
 
         if (currentStation == null) {
             RadioDroidApp radioDroidApp = (RadioDroidApp) getApplication();

--- a/app/src/main/java/net/programmierecke/radiodroid2/service/PlayerServiceUtil.java
+++ b/app/src/main/java/net/programmierecke/radiodroid2/service/PlayerServiceUtil.java
@@ -6,11 +6,8 @@ import android.content.Intent;
 import android.content.ServiceConnection;
 import android.content.res.Resources;
 import android.os.IBinder;
-import android.os.Parcel;
-import android.os.Parcelable;
 import android.os.RemoteException;
 import android.util.Log;
-
 import android.util.TypedValue;
 import android.widget.ImageView;
 
@@ -37,19 +34,28 @@ public class PlayerServiceUtil {
     private static boolean mBound;
     private static ServiceConnection serviceConnection;
 
-    public static void bind(Context context) {
+    public static void startService(Context context) {
         if (mBound) return;
 
         Intent anIntent = new Intent(context, PlayerService.class);
         anIntent.putExtra(PlayerService.PLAYER_SERVICE_NO_NOTIFICATION_EXTRA, true);
         mainContext = context;
         serviceConnection = getServiceConnection();
-        context.startService(anIntent);
         context.bindService(anIntent, serviceConnection, Context.BIND_AUTO_CREATE);
         mBound = true;
     }
 
-    public static void unBind(Context context) {
+    public static void bindService(Context context) {
+        if (mBound) return;
+
+        mainContext = context;
+        serviceConnection = getServiceConnection();
+        Intent anIntent = new Intent(context, PlayerService.class);
+        context.bindService(anIntent, serviceConnection, Context.BIND_AUTO_CREATE);
+        mBound = true;
+    }
+
+    private static void unBind(Context context) {
         try {
             context.unbindService(serviceConnection);
         } catch (Exception e) {
@@ -98,6 +104,7 @@ public class PlayerServiceUtil {
                     Log.d("PLAYER", "Service offline");
                 }
                 unBind(mainContext);
+                itsPlayerService = null;
             }
         };
     }
@@ -431,5 +438,16 @@ public class PlayerServiceUtil {
                 Log.e("", "" + e);
             }
         }
+    }
+
+    public static boolean isNotificationActive() {
+        if (itsPlayerService != null) {
+            try {
+                return itsPlayerService.isNotificationActive();
+            } catch (RemoteException e) {
+                Log.e("", "" + e);
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
We want to have a binder interface as long as PlayerService is alive
because PlayerServiceUtils is used indirectly from the service.
Thus, we only should unbind the service when its shutdown is explicitly
requested.

Now service is started via Context.bindService without calling
Context.startService beforehand, which wasn't doing what probably
was expected. Since bindService didn't wait for startService
completion.

Closes: #972