### PR TITLE
Revert String in English

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,7 +42,7 @@
     <string name="action_changed_lately">Changed Lately</string>
     <string name="action_currently_playing">Playing</string>
     <string name="action_tags">Tags</string>
-    <string name="action_countries">Countries/Regions</string>
+    <string name="action_countries">Countries</string>
     <string name="action_languages">Languages</string>
     <string name="action_edit">Edit</string>
     <string name="action_lyrics">Lyrics</string>


### PR DESCRIPTION
List introductions should be kept simple & snappy, though **country** is not completely exact. There is no problem to restore it because the app is for public use, not for political purpose.